### PR TITLE
抽取 build-firmware.sh 构建编排脚本，支撑私有 repo 反向 checkout

### DIFF
--- a/.github/workflows/openwrt-builder.yml
+++ b/.github/workflows/openwrt-builder.yml
@@ -37,10 +37,6 @@ env:
   REPO_URL: https://github.com/immortalwrt/immortalwrt
   REPO_BRANCH: openwrt-24.10
   OPENWRT_TAG: ${{ github.event.inputs.openwrt_tag }}
-  FEEDS_CONF: feeds.conf.default
-  CONFIG_FILE: .config
-  DIY_P1_SH: diy-part1.sh
-  DIY_P2_SH: diy-part2.sh
   UPLOAD_BIN_DIR: false
   UPLOAD_FIRMWARE: true
   UPLOAD_RELEASE: true
@@ -48,28 +44,43 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # lint: 静态护栏 (shellcheck + bash -n), 劣质 Bash 进不了构建
+  # ---------------------------------------------------------------------------
+  lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Shellcheck + bash -n
+        run: |
+          sudo apt-get -qq update && sudo apt-get -qq install shellcheck
+          # 入口脚本 + diy 脚本走 shellcheck; 纯库随入口被 source, 用 -x 跟进
+          shellcheck -x scripts/build-firmware.sh scripts/gen-matrix.sh diy-part1.sh diy-part2.sh
+          # build-lib.sh / diy-lib.sh 是被 source 的库, 单独 lint (shell=bash 指令在文件头)
+          shellcheck scripts/build-lib.sh scripts/diy-lib.sh
+          for f in scripts/build-firmware.sh scripts/gen-matrix.sh scripts/build-lib.sh scripts/diy-lib.sh diy-part1.sh diy-part2.sh tests/bdd-matrix-build.sh; do
+            bash -n "$f"
+          done
+
+  # ---------------------------------------------------------------------------
   # prepare: 把 workflow_dispatch 的 device choice 翻译成动态 matrix JSON
   # ---------------------------------------------------------------------------
   prepare:
+    needs: lint
     runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@main
       - name: Generate build matrix
         id: set-matrix
         env:
           # 经 env 注入而非直接插值, 杜绝表达式注入 (device 虽是 choice 受限枚举)
           INPUT_DEVICE: ${{ github.event.inputs.device }}
         run: |
-          ALL='["r2s","r3s","r5s","r5s-outdoor","r68s","x86"]'
-          # INPUT_DEVICE 为空仅出现在非 UI 触发(如 API)未带 input 时, 回退全量
-          if [ -z "$INPUT_DEVICE" ] || [ "$INPUT_DEVICE" = "all" ]; then
-            MATRIX="$ALL"
-          else
-            MATRIX="[\"$INPUT_DEVICE\"]"
-          fi
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-          echo "Build matrix: $MATRIX"
+          # 纯逻辑在 scripts/build-lib.sh (gen_matrix), 与 BDD 共用单一真相源
+          bash scripts/gen-matrix.sh
 
   # ---------------------------------------------------------------------------
   # build: 每个设备一个并行 job; DEVICE 注入 job 级 env, 全 step 可见
@@ -160,29 +171,6 @@ jobs:
         echo "OPENWRT_TAG=${{ env.OPENWRT_TAG }}" >> $GITHUB_ENV
         ln -sf /workdir/openwrt $GITHUB_WORKSPACE/openwrt
 
-    - name: Assemble seed configuration (common + device)
-      run: |
-        # 拼装契约: common.config + devices/$DEVICE/seed.config = .config
-        COMMON="config/common.config"
-        SEED="devices/$DEVICE/seed.config"
-        if [ ! -f "$COMMON" ]; then
-          echo "ERROR: $COMMON not found"; exit 1
-        fi
-        if [ ! -f "$SEED" ]; then
-          echo "ERROR: device seed not found: $SEED (device=$DEVICE)"; exit 1
-        fi
-        cat "$COMMON" "$SEED" > "$CONFIG_FILE"
-        echo "Assembled .config for device '$DEVICE' ($(wc -l < $CONFIG_FILE) lines)"
-
-        # Extract version info from seed BEFORE moving (defconfig may alter format)
-        VERSION_DIST=$(grep 'CONFIG_VERSION_DIST=' $CONFIG_FILE | cut -d'"' -f2)
-        VERSION_NUMBER=$(grep 'CONFIG_VERSION_NUMBER=' $CONFIG_FILE | cut -d'"' -f2)
-        VERSION_CODE=$(grep 'CONFIG_VERSION_CODE=' $CONFIG_FILE | cut -d'"' -f2)
-        echo "VERSION_DIST=$VERSION_DIST" >> $GITHUB_ENV
-        echo "VERSION_NUMBER=$VERSION_NUMBER" >> $GITHUB_ENV
-        echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
-        echo "Extracted version: ${VERSION_DIST}-${VERSION_NUMBER}-${VERSION_CODE}"
-
     - name: Cache OpenWrt dl & ccache
       uses: actions/cache@v4
       with:
@@ -199,98 +187,28 @@ jobs:
           openwrt-${{ env.OPENWRT_TAG }}-
           openwrt-
 
-    - name: Load custom feeds/drivers
-      run: |
-        [ -e $FEEDS_CONF ] && mv $FEEDS_CONF openwrt/feeds.conf.default
-        mkdir -p $GITHUB_WORKSPACE/drivers/;mkdir -p openwrt/package/kernel/drivers/
-        mv $GITHUB_WORKSPACE/drivers/* openwrt/package/kernel/ || true
-        chmod +x $DIY_P1_SH
-        cd openwrt
-        $GITHUB_WORKSPACE/$DIY_P1_SH
-
-    - name: Update feeds
-      run: cd openwrt && ./scripts/feeds update -a
-
-    - name: Install feeds
-      run: cd openwrt && ./scripts/feeds install -a
-
-    - name: Apply system customization (diy-part2)
-      run: |
-        [ -e files ] && mv files openwrt/files
-        mv $CONFIG_FILE openwrt/.config
-        chmod +x $DIY_P2_SH
-        cd openwrt
-        $GITHUB_WORKSPACE/$DIY_P2_SH
-
-    - name: Expand seed config and download packages
-      id: package
-      run: |
-        cd openwrt
-        echo "Expanding seed config with make defconfig..."
-        make defconfig
-        echo "Full config lines: $(wc -l < .config)"
-        make download -j8
-        # 清理 make download 产生的残缺包 (<1KB 的错误页/截断下载)。
-        # 关键: 限定 -maxdepth 1 -type f 只清 dl/ 顶层下载包, 不可递归进
-        # dl/go-mod-cache/ —— 后者含大量合法的小 .go 源文件 (如 frp 依赖的
-        # fatedier/golib/errors/errors.go 800B), 误删会导致 go 离线编译报
-        # "no required module provides package", frp [host] 编译失败。
-        find dl -maxdepth 1 -type f -size -1024c -exec ls -l {} \;
-        find dl -maxdepth 1 -type f -size -1024c -exec rm -f {} \;
-
-    - name: Preinstall clash core
-      run: |
-        cd openwrt
-
-        # Check OpenClash location (ImmortalWRT: feeds/packages, coolsnowwolf: feeds/small)
-        ls -l feeds/packages/net/openclash || ls -l feeds/luci/applications/luci-app-openclash || true
-        mkdir -p files/etc/openclash/core/
-
-        # 按目标架构选 Clash 核心: 探测 .config 的 TARGET 符号, 不再依赖分支名
-        if grep -q '^CONFIG_TARGET_x86=y' .config; then
-          CLASH_ARCH="amd64"
-        else
-          # rockchip_armv8 (r2s/r3s/r5s/r5s-outdoor/r68s) 全部 arm64
-          CLASH_ARCH="arm64"
-        fi
-        CLASH_CORE_URL="https://raw.githubusercontent.com/vernesong/OpenClash/core/master/meta/clash-linux-${CLASH_ARCH}.tar.gz"
-        echo "Device=$DEVICE -> Clash core arch=$CLASH_ARCH"
-
-        # 下载并解压 Clash 核心
-        curl -sL -m 30 --retry 2 "$CLASH_CORE_URL" -o /tmp/clash.tar.gz
-        tar zxvf /tmp/clash.tar.gz -C /tmp
-
-        # 赋予执行权限并移动核心文件到目标目录
-        chmod +x /tmp/clash
-        mv /tmp/clash files/etc/openclash/core/clash_meta
-
-        # 清理临时文件
-        rm -rf /tmp/clash.tar.gz
-
-        # 下载 GeoIP 数据库文件并移动到目标目录
-        curl -sL -m 30 --retry 2 https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat -o /tmp/GeoIP.dat
-        mv /tmp/GeoIP.dat files/etc/openclash/GeoIP.dat
-
-        # 下载 GeoSite 数据库文件并移动到目标目录
-        curl -sL -m 30 --retry 2 https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat -o /tmp/GeoSite.dat
-        mv /tmp/GeoSite.dat files/etc/openclash/GeoSite.dat
-
-        # 列出核心目录内容，确认文件是否正确放置
-        ls -l files/etc/openclash
-        ls -l files/etc/openclash/core
-
-    - name: Compile the firmware
+    - name: Build firmware core (build-firmware.sh)
       id: compile
       run: |
-        cd openwrt
-        make defconfig
-        export MAKE="gmake"
-        echo -e "$(nproc) thread compile with MAKE: $MAKE"
-        make -j$(nproc) || make -j1 || make -j1 V=s
-        echo "status=success" >> $GITHUB_OUTPUT
-        grep '^CONFIG_TARGET.*DEVICE.*=y' .config | sed -r 's/.*DEVICE_(.*)=y/\1/' > DEVICE_NAME
-        [ -s DEVICE_NAME ] && echo "DEVICE_NAME=_$(cat DEVICE_NAME)" >> $GITHUB_ENV
-        echo "FILE_DATE=_$(date +"%Y%m%d%H%M")" >> $GITHUB_ENV
+        # 构建核心 (拼.config → diy-part1 → feeds → diy-part2 → defconfig+download
+        # +清残包 → 预置 clash 核心 → make → 抽设备名) 全部收敛进可复用脚本,
+        # 私有 repo 反向 checkout 后可同样调用 (单一真相源)。
+        # CI 已自行 clone openwrt (为夹住上面的 cache action), 故走 --skip-clone;
+        # repo 根经 --repo-root 固化为 $GITHUB_WORKSPACE 绝对路径。
+        chmod +x scripts/build-firmware.sh
+        scripts/build-firmware.sh \
+          --device "$DEVICE" \
+          --tag "$OPENWRT_TAG" \
+          --repo-root "$GITHUB_WORKSPACE" \
+          --openwrt-dir "$GITHUB_WORKSPACE/openwrt" \
+          --skip-clone \
+          --vars-out "$GITHUB_WORKSPACE/build-vars.env"
+        # 跨 step 状态桥接: GHA 每 step 独立进程, source 出 step 即销毁,
+        # 故把脚本 emit 的 KEY=val 灌进 $GITHUB_ENV (非 source)。
+        cat "$GITHUB_WORKSPACE/build-vars.env" >> "$GITHUB_ENV"
+        # BUILD_STATUS=success 由脚本在 make 成功后 emit; 翻给后续 step 的 if 条件
+        grep -q '^BUILD_STATUS=success$' "$GITHUB_WORKSPACE/build-vars.env" \
+          && echo "status=success" >> "$GITHUB_OUTPUT"
 
     - name: Check space usage
       if: (!cancelled())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@
 - 2026年6月从"每设备一分支"合并为"main单分支 + 动态matrix构建"，并新增R3S、修复r68s废固件bug，详见issue #5
 - 2026年6月升级编译 tag v24.10.4→v24.10.6（根治 rust CI LLVM 404、移除临时 patch），引入 fail-loud diy 定制原语，修复 dl 残包清理误删 go-mod-cache 源文件的 bug，详见issue #9（6 设备全量 CI 验证通过）
 - 2026年6月为 r5s-outdoor 添加 mt7922 WiFi 6E 驱动（M.2 PCIe）及 SSID mW 预配置，详见 issue #13
+- 2026年6月抽取构建编排为可复用脚本 `scripts/build-firmware.sh`（纯库 build-lib.sh + 入口），支撑私有 repo 反向 checkout 注入私有镜像；新增 lint job 与 BDD B19-B30 抽取契约断言，详见 issue #14
 
 ## 技术栈与版本
 
@@ -58,7 +59,7 @@ main (单分支，承载全部设备)
 │   │   └── pre-feeds.sh          # 设备钩子: 注入 outdoor feed
 │   ├── r68s/seed.config          # NanoPi R68S delta (lunzn_fastrhino)
 │   └── x86/seed.config           # x86_64 + GRUB/EFI/VMDK delta
-└── tests/bdd-matrix-build.sh     # 36条 BDD 断言回归套件
+└── tests/bdd-matrix-build.sh     # 55条 BDD 断言回归套件
 ```
 
 ### 种子配置架构
@@ -95,8 +96,12 @@ main (单分支，承载全部设备)
 ├── devices/<dev>/
 │   ├── seed.config                   # 设备 delta
 │   └── pre-feeds.sh / post-feeds.sh  # 设备钩子 (按需)
-├── scripts/netdata/
-│   └── global_traffic.plugin         # Netdata插件
+├── scripts/
+│   ├── build-firmware.sh             # 构建编排入口 (可复用; 私有 repo 反向 checkout 复用)
+│   ├── build-lib.sh                  # 构建纯函数库 (gen_matrix/assemble_config/clash_arch/prune_residual_dl/clone_openwrt)
+│   ├── gen-matrix.sh                 # prepare job 薄壳 (device→matrix JSON)
+│   ├── diy-lib.sh                    # fail-loud 定制原语 (sed_required/append_required)
+│   └── netdata/global_traffic.plugin # Netdata插件
 ├── tests/
 │   └── bdd-matrix-build.sh           # BDD 回归套件
 ├── diy-part1.sh                      # Feeds阶段定制 (+ 设备钩子挂载)
@@ -110,7 +115,8 @@ main (单分支，承载全部设备)
 
 **关键特性**：
 - **触发**: 仅 `workflow_dispatch`，device choice（all/r2s/r3s/r5s/r5s-outdoor/r68s/x86）+ openwrt_tag
-- **双 job 架构**: `prepare`（device choice → 动态 matrix JSON）→ `build`（matrix.device 并行，fail-fast: false）
+- **三 job 架构**: `lint`（shellcheck + bash -n 静态护栏）→ `prepare`（device choice → 动态 matrix JSON，调 `scripts/gen-matrix.sh`）→ `build`（matrix.device 并行，fail-fast: false）
+- **构建编排抽取**: build job 的构建核心已抽成可复用脚本 `scripts/build-firmware.sh`，CI 与私有 repo 反向 checkout 共用单一真相源，详见 [docs/build-firmware-script.md](docs/build-firmware-script.md)
 - **源码管理**: 基于tag checkout（默认v24.10.6），支持手动指定
 - **架构探测**: Clash 核心按 `grep CONFIG_TARGET_x86` 选 amd64/arm64（不依赖分支名）
 - **缓存策略**: 只缓存 `dl`（源码包跨设备复用）+ `ccache`，不缓存 build_dir/staging_dir（单设备即超 10GB 全局上限，会触发 LRU 雪崩）
@@ -126,14 +132,16 @@ DEVICE: ${{ matrix.device }}  # build job 级注入，全 step 可见
 
 **构建流程**（build job）：
 ```
-1. Clone ImmortalWRT (git checkout tag)
-2. 拼装种子: cat config/common.config devices/$DEVICE/seed.config > .config
-3. 执行diy-part1.sh (feeds阶段 + 设备 pre-feeds 钩子)
-4. ./scripts/feeds update && install
-5. 执行diy-part2.sh (系统配置 + 设备 post-feeds 钩子)
-6. make defconfig (展开) → make download && make
-7. 重命名固件 (MCPE-251228-NN-*) → 上传Release → 清理旧Release
+[CI 基础设施] 磁盘优化 → checkout → 装依赖 → clone ImmortalWRT 到 /workdir (夹住 cache action)
+[scripts/build-firmware.sh --skip-clone] 构建核心:
+  拼装种子(common+seed) → 抽版本三元组 → diy-part1(feeds+pre-feeds钩子)
+  → feeds update/install → diy-part2(系统配置+post-feeds钩子)
+  → defconfig 展开 → make download → 清残包(prune_residual_dl)
+  → 预置 clash 核心 → make → 抽设备名 → emit build-vars.env
+[CI 基础设施] cat build-vars.env >> $GITHUB_ENV (跨 step 桥接)
+  → 重命名固件(MCPE-251228-NN-*) → 上传 Release → 清理旧 Release
 ```
+> 构建核心收敛进 `scripts/build-firmware.sh`（脚本分层/接口/三条绝对防御/私有反向 checkout 用法见 [docs/build-firmware-script.md](docs/build-firmware-script.md)）。CI 自行 clone 以夹住 cache action，故走 `--skip-clone`；私有 repo 反向调用时不传该参数让脚本自 clone。
 
 ## 定制配置
 
@@ -243,7 +251,7 @@ git push   # 单分支直接推，无需同步多分支
 ### 配置验证
 改动 config/devices 后跑本地回归，确认拼装契约与上游符号有效性不破：
 ```bash
-bash tests/bdd-matrix-build.sh   # 43 条断言，含拼装等价性 + 上游符号白名单 + fail-loud 原语 + dl 清理作用域
+bash tests/bdd-matrix-build.sh   # 55 条断言，含拼装等价性 + 上游符号白名单 + fail-loud 原语 + dl 清理作用域 + build-firmware.sh 抽取契约(B19-B30)
 ```
 
 ## 安全规范
@@ -268,6 +276,7 @@ git commit -m "fix: resolve build error, close #1"
 ## 参考资源
 
 ### 技术文档（docs/）
+- [docs/build-firmware-script.md](docs/build-firmware-script.md) — `scripts/build-firmware.sh` 构建编排脚本契约（脚本分层/参数/三条绝对防御/接缝设计）+ 私有 repo 反向 checkout 注入私有镜像的完整用法
 - [docs/rust-ci-llvm-404-fix.md](docs/rust-ci-llvm-404-fix.md) — rust [host] 编译 CI LLVM 404 的根因/临时 patch/升级根治方向（v24.10.4 feed pin 锁死 rust 1.89.0）
 - [docs/uwsgi-gcc-fix-journey.md](docs/uwsgi-gcc-fix-journey.md) — uwsgi 包 GCC 编译错误排查记录
 

--- a/diy-part1.sh
+++ b/diy-part1.sh
@@ -26,8 +26,10 @@ set -euo pipefail
 # --- Device-specific pre-feeds hook ---
 # matrix 构建注入 $DEVICE; 若该设备有 pre-feeds.sh 则在 feeds update 前执行
 # (例: r5s-outdoor 用它追加 outdoor-backup feed)。
-# ${VAR:-} 兼容 set -u 下 DEVICE/GITHUB_WORKSPACE 未注入的本地场景。
-DEVICE_HOOK="${GITHUB_WORKSPACE:-.}/devices/${DEVICE:-}/pre-feeds.sh"
+# repo 根取 ${MCPE_REPO_ROOT:-${GITHUB_WORKSPACE}} (均绝对路径): 经 build-firmware.sh
+# 调用时读 MCPE_REPO_ROOT (脚本固化的绝对路径); 旧 CI 直调时读 GITHUB_WORKSPACE。
+# 去掉 `.` 动态兜底: cd openwrt 后 `.` 会漂移, hook 文件找不到被静默跳过 (违 fail-loud)。
+DEVICE_HOOK="${MCPE_REPO_ROOT:-${GITHUB_WORKSPACE:-}}/devices/${DEVICE:-}/pre-feeds.sh"
 if [ -n "${DEVICE:-}" ] && [ -f "$DEVICE_HOOK" ]; then
   echo "==> Running device hook: devices/${DEVICE}/pre-feeds.sh"
   # shellcheck source=/dev/null  # 钩子路径运行期由 $DEVICE 决定, 无法静态解析

--- a/diy-part2.sh
+++ b/diy-part2.sh
@@ -137,8 +137,10 @@ sed_required "nginx: client_max_body_size 128M->1024M" \
 
 # --- Device-specific post-feeds hook ---
 # matrix 构建注入 $DEVICE; 若该设备有 post-feeds.sh 则在系统配置阶段执行
-# (当前无设备使用, 仅预留扩展点)。${DEVICE:-} 兼容 set -u 下 DEVICE 未注入的场景。
-DEVICE_HOOK="${GITHUB_WORKSPACE:-.}/devices/${DEVICE:-}/post-feeds.sh"
+# (例: r5s-outdoor 用它注入 WiFi UCI defaults)。
+# repo 根取 ${MCPE_REPO_ROOT:-${GITHUB_WORKSPACE}} (均绝对路径): build-firmware.sh
+# 调用读 MCPE_REPO_ROOT, 旧 CI 直调读 GITHUB_WORKSPACE; 去 `.` 兜底防 cd 漂移。
+DEVICE_HOOK="${MCPE_REPO_ROOT:-${GITHUB_WORKSPACE:-}}/devices/${DEVICE:-}/post-feeds.sh"
 if [ -n "${DEVICE:-}" ] && [ -f "$DEVICE_HOOK" ]; then
   echo "==> Running device hook: devices/${DEVICE}/post-feeds.sh"
   # shellcheck source=/dev/null

--- a/docs/build-firmware-script.md
+++ b/docs/build-firmware-script.md
@@ -1,0 +1,253 @@
+# 构建脚本契约文档
+
+把原先散落在 `openwrt-builder.yml` 各 step 里的构建核心收敛为可复用脚本，使私有 CI（mCPE-luci-app）能"反向 checkout mCPE-Release → overlay 向导包/provision 文件/机密 → 一次调用出私有镜像"。
+
+---
+
+## 脚本分层
+
+```
+scripts/
+├── build-lib.sh       # 纯函数库 (零副作用)
+├── build-firmware.sh  # 构建入口 (顶层 set -euo pipefail + trap)
+└── gen-matrix.sh      # prepare job 薄壳
+```
+
+**为何分离库与入口**：`build-lib.sh` 被三方共同 source：`build-firmware.sh`、`gen-matrix.sh`、`tests/bdd-matrix-build.sh`。若库本身带 `set -e`/`trap`，source 进 BDD 进程会把错误陷阱灌进测试框架——纯函数返回非零即杀死整套测试，哪怕是 `[ -f ... ]` 的"期望失败"用例。库的责任边界是函数定义，副作用由入口脚本承载。
+
+### build-lib.sh 暴露的函数
+
+| 函数 | 签名 | 说明 |
+|------|------|------|
+| `gen_matrix` | `<device>` | 空/"all" → 全设备 JSON 数组；其余 → 单元素数组。prepare job 与 BDD B07-B09 共用 |
+| `assemble_config` | `<common> <seed> [extra...]` | 顺序 cat 到 stdout：common（全设备交集）→ seed（设备 delta）→ extra（私有注入支点，后写覆盖前写） |
+| `clash_arch` | `<config-file>` | grep `CONFIG_TARGET_x86=y` → `amd64`；否则 → `arm64` |
+| `prune_residual_dl` | `<dl-dir>` | `-maxdepth 1 -type f -size -1024c` 只清 dl/ 顶层残缺包（<1 KB）；**严禁递归**，详见下方 |
+| `clone_openwrt` | `<repo-url> <branch> <tag> <dest>` | 浅克隆 ImmortalWRT；tag 非空则 fetch + checkout |
+
+---
+
+## build-firmware.sh 参数表
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--device <dev>` | **必填** | 设备标识，对应 `devices/<dev>/seed.config`；不存在则立即 exit 1 |
+| `--tag <tag>` | `v24.10.6` | ImmortalWRT 源码 tag，传给 `clone_openwrt` |
+| `--repo-root <path>` | 见"repo 根解析"节 | mCPE-Release 仓库根目录的绝对路径 |
+| `--openwrt-dir <path>` | `./openwrt` | OpenWrt 源码树落点（相对于调用者 cwd，内部立即转绝对路径） |
+| `--extra-config <file>` | 空 | 追加到 `.config` 尾部的额外符号文件（私有注入支点）；非空时文件必须存在 |
+| `--vars-out <file>` | `build-vars.env` | emit KEY=val 的环境变量文件；详见"接缝设计"节 |
+| `--skip-clone` | 不传 = 0 | 跳过 `clone_openwrt`，假定 `--openwrt-dir` 已存在（公开 CI 用，见下方） |
+
+### vars-out 文件的 KEY 列表
+
+脚本在不同阶段逐步 emit 到 `--vars-out` 文件：
+
+| KEY | 来源时机 | 说明 |
+|-----|----------|------|
+| `VERSION_DIST` | 拼装 .config 后（defconfig 前） | grep `CONFIG_VERSION_DIST=` |
+| `VERSION_NUMBER` | 同上 | grep `CONFIG_VERSION_NUMBER=` |
+| `VERSION_CODE` | 同上 | grep `CONFIG_VERSION_CODE=` |
+| `DEVICE_NAME` | make 完成后 | `_` 前缀 + 从 .config 抽取的上游设备符号（固件重命名用） |
+| `FILE_DATE` | make 完成后 | `_` 前缀 + `date +"%Y%m%d%H%M"` |
+| `BUILD_STATUS` | make 成功后末尾 | 固定值 `success`；make 失败脚本直接 exit，此行不会出现 |
+
+---
+
+## 三条绝对防御
+
+私有 CI 不跑本仓 BDD 套件，脚本内部必须内建守门逻辑，不能依赖外部测试保障。
+
+### 防御 1：设备强校验
+
+```bash
+if [ ! -f "$MCPE_REPO_ROOT/devices/$DEVICE/seed.config" ]; then
+  echo "ERROR: Invalid device: $DEVICE (no $SEED)" >&2; exit 1
+fi
+```
+
+**为何**：`make defconfig` 会静默丢弃无效 `CONFIG_TARGET_*DEVICE*` 符号并回退到上游默认设备（r68s 历史教训：`friendlyarm_nanopi-r68s` 无效，默认出了 `ariaboard_photonicat` 废固件，构建成功但产物不对）。脚本在拼装前校验 seed 存在，无效设备在最早阶段 fail-loud。
+
+### 防御 2：`--skip-clone` 时先 git clean
+
+```bash
+git -C "$OPENWRT_DIR" clean -fdx -e dl -e .ccache
+```
+
+**为何**：复用已 clone 的源码树时，上次构建残留的 `.config` 碎片、临时包补丁等会污染本次构建。`-e dl -e .ccache` 保留缓存，其余全清，保证构建幂等。不加这一步，多轮调试跑下来几乎必出玄学问题。
+
+### 防御 3：`build-vars.env` 启动即 rm
+
+```bash
+rm -f "$VARS_OUT"
+emit() { printf '%s=%s\n' "$1" "$2" >> "$VARS_OUT"; }
+```
+
+**为何**：脚本在任何校验/退出之前就清空 vars 文件，包括早期 exit 路径。若不清，多轮调试下旧 KEY 残留堆积，`cat >> $GITHUB_ENV` 会把过期值（如上次的 `VERSION_CODE`）灌进当前 step，排查时极难定位。即使校验失败，留下的也是干净（空）文件而非垃圾堆。
+
+---
+
+## repo 根解析优先级
+
+```
+--repo-root CLI 参数  >  $MCPE_REPO_ROOT 环境变量  >  脚本物理位置 ($SELF_DIR/..)
+```
+
+**严禁 `$(pwd)` 的原因**：反向调用时，私有 CI 在私有 repo 根目录执行 `./mCPE-Release/scripts/build-firmware.sh`，此时 `$(pwd)` 是私有 repo 根（比如 `/workspace/mCPE-luci-app`）。若用 `$(pwd)` 推导 repo 根，脚本会去私有 repo 里找 `devices/<dev>/seed.config`，触发防御 1 强校验误杀构建，更严重的是 `diy-part1.sh`/`diy-part2.sh` 也会找错路径，静默执行私有 repo 里不存在的钩子逻辑。
+
+脚本基于 `BASH_SOURCE[0]` 物理位置（`$SELF_DIR = scripts/`，`$SELF_DIR/..` = mCPE-Release 根）硬寻址，无论从哪个目录调用都正确。`MCPE_REPO_ROOT` 经 `export` 传给下游 `diy-part1.sh`/`diy-part2.sh` 里的设备钩子，它们也需要定位 `devices/<dev>/*.sh`。
+
+---
+
+## 接缝设计：build-vars.env + GHA `cat >> $GITHUB_ENV`
+
+脚本与 CI 之间**不共享进程**，通过文件传递状态：
+
+```bash
+# build-firmware.sh 内部
+emit VERSION_DIST "MCPE-251228"
+emit BUILD_STATUS success
+
+# openwrt-builder.yml build step 末尾
+cat "$GITHUB_WORKSPACE/build-vars.env" >> "$GITHUB_ENV"
+```
+
+**为何不能 source**：GitHub Actions 每个 step 在独立子进程里执行，`source build-vars.env` 设置的环境变量在 step 结束时随进程销毁，后续 step 看不到。`cat >> $GITHUB_ENV` 是 GHA 官方的跨 step 环境传递机制，写入后当前 job 的所有后续 step 均可通过 `env.KEY` 或 `$KEY` 引用。
+
+---
+
+## 公开 CI 用法（--skip-clone 模式）
+
+公开 CI 用 `--skip-clone` 的原因：GitHub Actions 的 `cache action` 必须**夹在 clone 与 download 之间**才能有效恢复 dl/ 缓存。如果让脚本自己 clone，cache restore 就没有插入点，dl/ 缓存形同虚设（每次全量重下载，构建时间倍增）。
+
+所以公开 CI 把 clone 独立成一个 step，在 clone 和 `build-firmware.sh` 之间插入 `cache action`，然后传 `--skip-clone`：
+
+```yaml
+- name: Clone openwrt source code
+  working-directory: /workdir
+  run: |
+    git clone $REPO_URL -b $REPO_BRANCH openwrt --depth=1
+    cd openwrt && git fetch --depth=1 origin tag ${{ env.OPENWRT_TAG }}
+    git checkout tags/${{ env.OPENWRT_TAG }}
+
+- name: Cache OpenWrt dl & ccache
+  uses: actions/cache@v4
+  with:
+    path: |
+      openwrt/dl
+      openwrt/.ccache
+    key: openwrt-${{ env.OPENWRT_TAG }}-${{ matrix.device }}-...
+
+- name: Build firmware core (build-firmware.sh)
+  run: |
+    scripts/build-firmware.sh \
+      --device "$DEVICE" \
+      --tag "$OPENWRT_TAG" \
+      --repo-root "$GITHUB_WORKSPACE" \
+      --openwrt-dir "$GITHUB_WORKSPACE/openwrt" \
+      --skip-clone \
+      --vars-out "$GITHUB_WORKSPACE/build-vars.env"
+    cat "$GITHUB_WORKSPACE/build-vars.env" >> "$GITHUB_ENV"
+```
+
+---
+
+## 私有 CI 反向 checkout 完整用法
+
+这是本脚本抽取的核心价值。mCPE-luci-app 的 CI 反向 checkout mCPE-Release，overlay 向导包/provision 文件/机密后，调同一套脚本出私有镜像。
+
+```yaml
+# mCPE-luci-app/.github/workflows/build-private.yml (示意)
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        device: [r2s, r5s-outdoor, x86]  # 按需
+    env:
+      DEVICE: ${{ matrix.device }}
+
+    steps:
+      # 1. checkout 私有 repo 自身 (向导源码 + uci 模板)
+      - name: Checkout mCPE-luci-app
+        uses: actions/checkout@v4
+        with:
+          path: mCPE-luci-app
+
+      # 2. 反向 checkout 公开 mCPE-Release (构建脚本单一真相源)
+      - name: Checkout mCPE-Release
+        uses: actions/checkout@v4
+        with:
+          repository: WooDragon/mCPE-Release
+          path: mCPE-Release
+
+      # 3. overlay wizard app 到 package/
+      #    build-firmware.sh 的 diy-part1 会 source devices/<dev>/pre-feeds.sh,
+      #    故向导包只需落在 mCPE-Release/package/ 下，feeds install 会纳入
+      - name: Overlay wizard package
+        run: |
+          cp -a mCPE-luci-app/luci-app-mcpe-wizard \
+            mCPE-Release/package/luci-app-mcpe-wizard
+
+      # 4. 生成 extra.config 声明 wizard 包符号 (--extra-config 殿后, 后写覆盖)
+      - name: Generate extra.config
+        run: |
+          cat > extra.config <<'EOF'
+          CONFIG_PACKAGE_luci-app-mcpe-wizard=y
+          EOF
+
+      # 5. 把 provision 文件/uci 模板放 files/ (build-firmware.sh 会 cp 进 openwrt/files)
+      - name: Overlay provision files
+        run: |
+          cp -a mCPE-luci-app/files mCPE-Release/files
+
+      # 6. 用 Actions Secrets 渲染机密占位符 (C 类机密必须走 Secrets)
+      #    sed 内联替换模板里的 __FRP_TOKEN__ 等占位符
+      - name: Render secrets into templates
+        env:
+          FRP_TOKEN: ${{ secrets.FRP_TOKEN }}
+          PUSHBOT_TOKEN: ${{ secrets.PUSHBOT_TOKEN }}
+        run: |
+          find mCPE-Release/files -type f \( -name "*.conf" -o -name "*.sh" \) | xargs \
+            sed -i "s|__FRP_TOKEN__|${FRP_TOKEN}|g; s|__PUSHBOT_TOKEN__|${PUSHBOT_TOKEN}|g"
+
+      # 7. 调 build-firmware.sh —— 不传 --skip-clone, 让脚本自己 clone
+      #    (私有 CI 无 cache action 约束, 无需分离 clone step)
+      - name: Build private firmware
+        run: |
+          chmod +x mCPE-Release/scripts/build-firmware.sh
+          mCPE-Release/scripts/build-firmware.sh \
+            --device "$DEVICE" \
+            --tag "v24.10.6" \
+            --repo-root "./mCPE-Release" \
+            --openwrt-dir "./openwrt" \
+            --extra-config "./extra.config" \
+            --vars-out "./build-vars.env"
+
+      # 8. 产物发私有 S3 (固件烤进了 C 类机密, 绝对不发公开 GitHub Release)
+      - name: Upload to private S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET }}
+        run: |
+          source ./build-vars.env
+          # 固件路径由 make 产出; 替换为实际 S3 桶名
+          aws s3 cp openwrt/bin/targets/ \
+            "s3://<私有桶名>/firmware/${DEVICE}/${FILE_DATE}/" \
+            --recursive --exclude "packages/*"
+```
+
+---
+
+## 安全铁律
+
+### C 类机密必须走 GitHub Actions Secrets
+
+GitHub Actions 的公开 run log 对所有人可见。Secrets 在 log 里自动 mask 为 `***`，但**从私有 repo checkout 进来的文件内容不是 secret**，不会被 mask。任何 `set -x`、`cat`、`echo` 都会把文件里的明文机密打进公开 log。
+
+机密（frp token/sk、pushbot pp_token、clash 面板密码）必须在 `mCPE-Release` 的 Actions Secrets 中声明，私有 repo 文件里只放占位符（如 `__FRP_TOKEN__`），由 action step 6 在构建时填充。
+
+### 烤进机密的固件必须发私有 S3，禁止发公开 GitHub Release
+
+这是物理事实，不是策略：`binwalk` 解包公开 Release 中的固件 → 直接读出所有烤进去的明文机密。Secrets 只保护构建日志，保护不了已公开的产物。公开 mCPE-Release 的 GitHub Release 只发干净基础固件（零业务配置，无机密）；私有镜像（含 C 类机密）必须发私有 S3。

--- a/scripts/build-firmware.sh
+++ b/scripts/build-firmware.sh
@@ -145,8 +145,15 @@ if [ -f "$MCPE_REPO_ROOT/feeds.conf.default" ]; then
   cp "$MCPE_REPO_ROOT/feeds.conf.default" "$OPENWRT_DIR/feeds.conf.default"
 fi
 mkdir -p "$OPENWRT_DIR/package/kernel/drivers/"
-# drivers/* 不匹配 .ignore (无 dotglob) -> 当前为空时整体跳过; nullglob 防字面量残留
-( shopt -s nullglob; files=("$MCPE_REPO_ROOT"/drivers/*); [ ${#files[@]} -gt 0 ] && cp -a "${files[@]}" "$OPENWRT_DIR/package/kernel/" || true )
+# drivers/* 不匹配 .ignore (无 dotglob) -> 当前为空时整体跳过; nullglob 防字面量残留。
+# 用显式 if-then (非 A && B || C): cp 失败应随 set -e 中断, 不被 || true 吞掉。
+(
+  shopt -s nullglob
+  driver_files=("$MCPE_REPO_ROOT"/drivers/*)
+  if [ ${#driver_files[@]} -gt 0 ]; then
+    cp -a "${driver_files[@]}" "$OPENWRT_DIR/package/kernel/"
+  fi
+)
 # DEVICE/MCPE_REPO_ROOT 经 export 传给子脚本; 在 openwrt 目录内执行 (与 CI 一致)。
 export DEVICE
 chmod +x "$MCPE_REPO_ROOT/diy-part1.sh"

--- a/scripts/build-firmware.sh
+++ b/scripts/build-firmware.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# =============================================================================
+# scripts/build-firmware.sh — mCPE 固件构建编排入口 (单一真相源)
+# =============================================================================
+# 把原先散落在 .github/workflows/openwrt-builder.yml 各 step 的"构建核心"
+# (clone → 拼 .config → diy-part1 → feeds → diy-part2 → defconfig+download+清残包
+#  → 预置 clash 核心 → make → 重命名固件) 收敛成一个可复用脚本。
+#
+# 两类调用方:
+#   1. 公开 CI (openwrt-builder.yml): clone 与 cache action 必须分离 (cache 夹在
+#      clone 与 download 之间), 故 CI 自行 clone 后用 --skip-clone 调本脚本跑其余。
+#   2. 反向私有注入 (mCPE-luci-app): 私有 CI 反向 checkout 本 repo, overlay
+#      wizard 包 (--extra-config 追加包符号) / provision 文件 (files/ overlay) /
+#      机密渲染后, 一次调用跑完整 clone→make, 产物发私有 S3。
+#
+# 接缝: 脚本零 CI 耦合, 只把版本/固件路径等 emit 到 --vars-out 文件 (KEY=val)。
+#       CI 侧 `cat build-vars.env >> $GITHUB_ENV` 跨 step 桥接 (GHA 每 step 独立
+#       进程, source 出 step 即销毁, 故必须写文件 + GITHUB_ENV)。
+#
+# 用法:
+#   scripts/build-firmware.sh --device <dev> [--tag v24.10.6] [--repo-root .]
+#     [--openwrt-dir ./openwrt] [--extra-config <f>] [--vars-out build-vars.env]
+#     [--skip-clone]
+# =============================================================================
+set -euo pipefail
+trap 'echo "ERROR: build-firmware.sh failed (line $LINENO, exit $?)" >&2' ERR
+
+# 脚本自身物理位置 (绝对路径硬寻址的锚点; 严禁 $(pwd) —— 反向调用时 cwd 是私有
+# repo 根, 会去私有环境找 seed.config 触发强校验误杀)。
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/build-lib.sh
+. "$SELF_DIR/build-lib.sh"
+
+# --- 默认值 (上游源/分支可被 env 覆盖, 与 workflow env 同名) -------------------
+REPO_URL="${REPO_URL:-https://github.com/immortalwrt/immortalwrt}"
+REPO_BRANCH="${REPO_BRANCH:-openwrt-24.10}"
+DEVICE=""
+TAG="v24.10.6"
+REPO_ROOT_ARG=""
+OPENWRT_DIR="./openwrt"
+EXTRA_CONFIG=""
+VARS_OUT="build-vars.env"
+SKIP_CLONE=0
+
+usage() {
+  sed -n '2,27p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# abspath <path>: 解析为绝对路径, 即使路径尚不存在 (取父目录 + basename)。
+abspath() {
+  local p="$1"
+  if [ -d "$p" ]; then
+    (cd "$p" && pwd)
+  else
+    echo "$(cd "$(dirname "$p")" && pwd)/$(basename "$p")"
+  fi
+}
+
+# --- 参数解析 ----------------------------------------------------------------
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --device)       DEVICE="$2"; shift 2 ;;
+    --tag)          TAG="$2"; shift 2 ;;
+    --repo-root)    REPO_ROOT_ARG="$2"; shift 2 ;;
+    --openwrt-dir)  OPENWRT_DIR="$2"; shift 2 ;;
+    --extra-config) EXTRA_CONFIG="$2"; shift 2 ;;
+    --vars-out)     VARS_OUT="$2"; shift 2 ;;
+    --skip-clone)   SKIP_CLONE=1; shift ;;
+    -h|--help)      usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# --- repo 根解析 (优先级: --repo-root > $MCPE_REPO_ROOT > 脚本物理位置) --------
+# 严禁 $(pwd): 反向调用场景私有 CI 在自己根目录执行 ./mCPE-Release/scripts/...,
+# $(pwd) 是私有 repo 根; 基于脚本物理位置 ($SELF_DIR/..) 才是真绝对路径。
+if [ -n "$REPO_ROOT_ARG" ]; then
+  MCPE_REPO_ROOT="$(abspath "$REPO_ROOT_ARG")"
+elif [ -n "${MCPE_REPO_ROOT:-}" ]; then
+  MCPE_REPO_ROOT="$(abspath "$MCPE_REPO_ROOT")"
+else
+  MCPE_REPO_ROOT="$(cd "$SELF_DIR/.." && pwd)"
+fi
+export MCPE_REPO_ROOT   # 下游 diy-part1/2 的 hook 读它定位 devices/<dev>/*.sh
+
+OPENWRT_DIR="$(abspath "$OPENWRT_DIR")"
+
+# --- 绝对防御 3: build-vars.env 幂等 (启动即清, 防多次调试 >> 堆成垃圾场) -------
+# 必须在任何校验/退出之前: 校验失败提前 exit 也应留下干净 (空) 产物, 不残留旧键。
+rm -f "$VARS_OUT"
+emit() { printf '%s=%s\n' "$1" "$2" >> "$VARS_OUT"; }
+
+# --- 绝对防御 1: 设备有效性强校验 (复刻 B13 意图进脚本, 私有 CI 不跑本仓 BDD) --
+if [ -z "$DEVICE" ]; then
+  echo "ERROR: --device is required" >&2; usage >&2; exit 2
+fi
+SEED="$MCPE_REPO_ROOT/devices/$DEVICE/seed.config"
+if [ ! -f "$SEED" ]; then
+  echo "ERROR: Invalid device: $DEVICE (no $SEED)" >&2; exit 1
+fi
+COMMON="$MCPE_REPO_ROOT/config/common.config"
+if [ ! -f "$COMMON" ]; then
+  echo "ERROR: $COMMON not found" >&2; exit 1
+fi
+if [ -n "$EXTRA_CONFIG" ] && [ ! -f "$EXTRA_CONFIG" ]; then
+  echo "ERROR: --extra-config file not found: $EXTRA_CONFIG" >&2; exit 1
+fi
+
+echo "==> build-firmware: device=$DEVICE tag=$TAG repo-root=$MCPE_REPO_ROOT openwrt-dir=$OPENWRT_DIR"
+
+# --- 1. clone + checkout tag (CI 走 --skip-clone 自行 clone 以夹 cache action) -
+if [ "$SKIP_CLONE" -eq 1 ]; then
+  if [ ! -d "$OPENWRT_DIR" ]; then
+    echo "ERROR: --skip-clone but $OPENWRT_DIR does not exist" >&2; exit 1
+  fi
+  # 绝对防御 2: 复用已 clone 的树时先清残局 (保 dl/.ccache 缓存),
+  # 杜绝上次 .config 碎片/临时包污染本次构建。
+  echo "==> --skip-clone: cleaning $OPENWRT_DIR (preserving dl/.ccache)"
+  git -C "$OPENWRT_DIR" clean -fdx -e dl -e .ccache
+else
+  clone_openwrt "$REPO_URL" "$REPO_BRANCH" "$TAG" "$OPENWRT_DIR"
+fi
+
+# --- 2. 拼装 .config (common + seed [+ extra]) + 抽版本三元组 ------------------
+CONFIG_FILE="$OPENWRT_DIR/.config"
+# extra 殿后: 私有注入支点 (wizard 包符号), 后写覆盖前写。
+# shellcheck disable=SC2086  # EXTRA_CONFIG 为单路径或空, 刻意不引号以便空时不传参
+assemble_config "$COMMON" "$SEED" ${EXTRA_CONFIG:+"$EXTRA_CONFIG"} > "$CONFIG_FILE"
+echo "Assembled .config for device '$DEVICE' ($(wc -l < "$CONFIG_FILE") lines)"
+
+# 抽版本信息 (在 defconfig 改格式前; emit 到 vars 文件供 CI 重命名固件用)
+VERSION_DIST=$(grep 'CONFIG_VERSION_DIST=' "$CONFIG_FILE" | cut -d'"' -f2)
+VERSION_NUMBER=$(grep 'CONFIG_VERSION_NUMBER=' "$CONFIG_FILE" | cut -d'"' -f2)
+VERSION_CODE=$(grep 'CONFIG_VERSION_CODE=' "$CONFIG_FILE" | cut -d'"' -f2)
+emit VERSION_DIST "$VERSION_DIST"
+emit VERSION_NUMBER "$VERSION_NUMBER"
+emit VERSION_CODE "$VERSION_CODE"
+echo "Extracted version: ${VERSION_DIST}-${VERSION_NUMBER}-${VERSION_CODE}"
+
+# --- 3. diy-part1 (feeds 阶段 + 设备 pre-feeds 钩子) ---------------------------
+# 先 overlay 自定义 feeds.conf.default / drivers (P3TERX 扩展点; 公开 repo 当前
+# 二者皆空 -> no-op, 行为与旧 CI 一致; 私有注入可借此铺 feeds/驱动)。用 cp 不用
+# mv: 不破坏 repo-root, --skip-clone 重跑幂等。
+if [ -f "$MCPE_REPO_ROOT/feeds.conf.default" ]; then
+  cp "$MCPE_REPO_ROOT/feeds.conf.default" "$OPENWRT_DIR/feeds.conf.default"
+fi
+mkdir -p "$OPENWRT_DIR/package/kernel/drivers/"
+# drivers/* 不匹配 .ignore (无 dotglob) -> 当前为空时整体跳过; nullglob 防字面量残留
+( shopt -s nullglob; files=("$MCPE_REPO_ROOT"/drivers/*); [ ${#files[@]} -gt 0 ] && cp -a "${files[@]}" "$OPENWRT_DIR/package/kernel/" || true )
+# DEVICE/MCPE_REPO_ROOT 经 export 传给子脚本; 在 openwrt 目录内执行 (与 CI 一致)。
+export DEVICE
+chmod +x "$MCPE_REPO_ROOT/diy-part1.sh"
+( cd "$OPENWRT_DIR" && "$MCPE_REPO_ROOT/diy-part1.sh" )
+
+# --- 4. feeds update + install ------------------------------------------------
+( cd "$OPENWRT_DIR" && ./scripts/feeds update -a && ./scripts/feeds install -a )
+
+# --- 5. diy-part2 (系统配置 + 设备 post-feeds 钩子) ----------------------------
+# files/ overlay: 私有注入把 provision.sh+templates 放 $MCPE_REPO_ROOT/files/,
+# 与 CI 同款 "有则搬进 openwrt/files" 语义。
+if [ -d "$MCPE_REPO_ROOT/files" ]; then
+  rm -rf "$OPENWRT_DIR/files"
+  cp -a "$MCPE_REPO_ROOT/files" "$OPENWRT_DIR/files"
+fi
+chmod +x "$MCPE_REPO_ROOT/diy-part2.sh"
+( cd "$OPENWRT_DIR" && "$MCPE_REPO_ROOT/diy-part2.sh" )
+
+# --- 6. defconfig 展开 + download + 清残包 ------------------------------------
+(
+  cd "$OPENWRT_DIR"
+  echo "Expanding seed config with make defconfig..."
+  make defconfig
+  echo "Full config lines: $(wc -l < .config)"
+  make download -j8
+)
+prune_residual_dl "$OPENWRT_DIR/dl"
+
+# --- 7. 预置 clash 核心 + GeoIP/GeoSite ---------------------------------------
+(
+  cd "$OPENWRT_DIR"
+  ls -l feeds/packages/net/openclash || ls -l feeds/luci/applications/luci-app-openclash || true
+  mkdir -p files/etc/openclash/core/
+  CLASH_ARCH="$(clash_arch .config)"
+  CLASH_CORE_URL="https://raw.githubusercontent.com/vernesong/OpenClash/core/master/meta/clash-linux-${CLASH_ARCH}.tar.gz"
+  echo "Device=$DEVICE -> Clash core arch=$CLASH_ARCH"
+  curl -sL -m 30 --retry 2 "$CLASH_CORE_URL" -o /tmp/clash.tar.gz
+  tar zxvf /tmp/clash.tar.gz -C /tmp
+  chmod +x /tmp/clash
+  mv /tmp/clash files/etc/openclash/core/clash_meta
+  rm -rf /tmp/clash.tar.gz
+  curl -sL -m 30 --retry 2 https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat -o /tmp/GeoIP.dat
+  mv /tmp/GeoIP.dat files/etc/openclash/GeoIP.dat
+  curl -sL -m 30 --retry 2 https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat -o /tmp/GeoSite.dat
+  mv /tmp/GeoSite.dat files/etc/openclash/GeoSite.dat
+  ls -l files/etc/openclash
+  ls -l files/etc/openclash/core
+)
+
+# --- 8. 编译固件 --------------------------------------------------------------
+(
+  cd "$OPENWRT_DIR"
+  make defconfig
+  export MAKE="gmake"
+  echo -e "$(nproc) thread compile with MAKE: $MAKE"
+  make -j"$(nproc)" || make -j1 || make -j1 V=s
+)
+
+# --- 9. 抽设备名 (固件重命名/artifact 命名用; emit 到 vars 文件) --------------
+(
+  cd "$OPENWRT_DIR"
+  grep '^CONFIG_TARGET.*DEVICE.*=y' .config | sed -r 's/.*DEVICE_(.*)=y/\1/' > DEVICE_NAME
+)
+if [ -s "$OPENWRT_DIR/DEVICE_NAME" ]; then
+  emit DEVICE_NAME "_$(cat "$OPENWRT_DIR/DEVICE_NAME")"
+fi
+emit FILE_DATE "_$(date +"%Y%m%d%H%M")"
+emit BUILD_STATUS success
+
+echo "==> build-firmware: done. vars written to $VARS_OUT"

--- a/scripts/build-lib.sh
+++ b/scripts/build-lib.sh
@@ -1,0 +1,89 @@
+# shellcheck shell=bash
+# =============================================================================
+# scripts/build-lib.sh — 构建编排的纯函数库 (单一真相源)
+# =============================================================================
+# 设计契约 (遵循既有 scripts/diy-lib.sh 模式):
+#   本文件是**纯库**: 无 set -e / 无 trap / 无顶层副作用, 只定义函数。
+#   被三方共同 source —— scripts/build-firmware.sh (构建入口)、
+#   scripts/gen-matrix.sh (prepare job 薄壳)、tests/bdd-matrix-build.sh (回归)。
+#   入口脚本带 `set -euo pipefail` + trap; 若本库也带 set -e, source 进 BDD
+#   会把错误陷阱灌进测试进程, 纯函数返回非 0 即杀死整个套件 —— 故严禁。
+#
+# 用法:
+#   . "$(dirname "${BASH_SOURCE[0]}")/build-lib.sh"   # 入口/测试统一这样 source
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# gen_matrix <device>
+#   把 workflow_dispatch 的 device choice 翻译成动态 matrix JSON。
+#   空或 "all" → 全设备数组; 其余 → 单元素数组。
+#   (单一真相源: prepare job 与 BDD B07-B09 共用本函数, 不再各自复刻)
+# -----------------------------------------------------------------------------
+gen_matrix() {
+  local device="$1"
+  local all='["r2s","r3s","r5s","r5s-outdoor","r68s","x86"]'
+  if [ -z "$device" ] || [ "$device" = "all" ]; then
+    echo "$all"
+  else
+    echo "[\"$device\"]"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# assemble_config <common> <seed> [extra...]
+#   拼装契约: common.config + devices/<dev>/seed.config [+ 可选 extra] → stdout。
+#   顺序铁律: common 在前 (全设备交集), seed 居中 (设备 delta), extra 殿后
+#   (私有注入支点, 如 wizard 包符号; 后写覆盖前写, 故 extra 能追加/改写)。
+#   纯函数: 只 cat 到 stdout, 由调用方决定落盘位置。
+# -----------------------------------------------------------------------------
+assemble_config() {
+  cat "$@"
+}
+
+# -----------------------------------------------------------------------------
+# clash_arch <config-file>
+#   按 .config 的 TARGET 符号选 Clash 核心架构, 不依赖分支名。
+#   x86 → amd64; 其余 (rockchip_armv8: r2s/r3s/r5s/r5s-outdoor/r68s) → arm64。
+# -----------------------------------------------------------------------------
+clash_arch() {
+  local config="$1"
+  if grep -q '^CONFIG_TARGET_x86=y' "$config"; then
+    echo amd64
+  else
+    echo arm64
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# prune_residual_dl <dl-dir>
+#   清理 make download 产生的残缺包 (<1KB 的错误页/截断下载)。
+#   关键作用域: -maxdepth 1 -type f 只清 dl/ 顶层下载包, 不可递归进
+#   dl/go-mod-cache/ —— 后者含大量合法的小 .go 源文件 (如 frp 依赖的
+#   fatedier/golib/errors/errors.go 800B), 误删会导致 go 离线编译报
+#   "no required module provides package", frp [host] 编译失败 (issue #9)。
+#   (单一真相源: workflow 与 BDD B18 共用本函数)
+# -----------------------------------------------------------------------------
+prune_residual_dl() {
+  local dl="$1"
+  find "$dl" -maxdepth 1 -type f -size -1024c -exec ls -l {} \;
+  find "$dl" -maxdepth 1 -type f -size -1024c -exec rm -f {} \;
+}
+
+# -----------------------------------------------------------------------------
+# clone_openwrt <repo-url> <repo-branch> <tag> <dest>
+#   浅克隆 ImmortalWRT 到 <dest>, 若给了 <tag> 则 checkout 该 tag。
+#   (单一真相源: build-firmware.sh 默认路径与 CI 的 clone step 共用本函数,
+#    因 cache action 必须夹在 clone 与 download 之间, CI 走 --skip-clone,
+#    自行在 YAML 里调本函数 clone, 故 clone 逻辑只此一份)
+# -----------------------------------------------------------------------------
+clone_openwrt() {
+  local url="$1" branch="$2" tag="$3" dest="$4"
+  git clone "$url" -b "$branch" "$dest" --depth=1
+  if [ -n "$tag" ]; then
+    echo "Checking out tag: $tag"
+    git -C "$dest" fetch --depth=1 origin tag "$tag"
+    git -C "$dest" checkout "tags/$tag"
+  else
+    echo "No tag specified, using latest from branch: $branch"
+  fi
+}

--- a/scripts/gen-matrix.sh
+++ b/scripts/gen-matrix.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# =============================================================================
+# scripts/gen-matrix.sh — prepare job 薄入口: device choice → 动态 matrix JSON
+# =============================================================================
+# 纯逻辑 (gen_matrix) 在 scripts/build-lib.sh, 与 BDD B07-B09 共用单一真相源。
+# 本壳只负责 source 库 + 调函数 + 输出 (stdout 给本地, $GITHUB_OUTPUT 给 CI)。
+#
+# 用法:
+#   scripts/gen-matrix.sh <device>          # 本地: matrix JSON 打到 stdout
+#   INPUT_DEVICE=all scripts/gen-matrix.sh   # 等价 (无参时读 $INPUT_DEVICE)
+# =============================================================================
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/build-lib.sh
+. "$SELF_DIR/build-lib.sh"
+
+# device 取值: 位置参数优先, 回退 $INPUT_DEVICE (CI 经 env 注入, 防表达式注入)
+DEVICE="${1:-${INPUT_DEVICE:-}}"
+MATRIX="$(gen_matrix "$DEVICE")"
+
+echo "Build matrix: $MATRIX" >&2
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+fi
+echo "$MATRIX"

--- a/tests/bdd-matrix-build.sh
+++ b/tests/bdd-matrix-build.sh
@@ -2,11 +2,17 @@
 # =============================================================================
 # tests/bdd-matrix-build.sh — 单分支 matrix 构建的本地 BDD 回归套件
 # =============================================================================
-# 断言纯文本契约(不烧 CI), 覆盖 4 类行为:
+# 断言纯文本契约(不烧 CI), 覆盖 7 类行为:
 #   1. 拼装等价性 (B01/B02/B03) — Never break userspace 铁律
 #   2. 设备钩子机制 (B04/B05/B06)
-#   3. matrix 生成逻辑 (B07/B08/B09)
+#   3. matrix 生成逻辑 (B07/B08/B09) — 调 build-lib.sh 真函数
 #   4. 固件命名前缀 & 架构探测 & release 隔离 (B10/B11/B12)
+#   5. fail-loud 定制原语 (B15/B16/B17)
+#   6. dl 残包清理作用域 (B18/B18b) — 调 build-lib.sh 真函数
+#   7. build-firmware.sh 抽取契约 (B19-B30) — 反向私有注入支撑
+#
+# 单一真相源: B07-B09/B11/B18 测的是 scripts/build-lib.sh 的真函数 (非复刻),
+#   改一处不必同步两处。
 #
 # 用法: bash tests/bdd-matrix-build.sh   (在仓库根目录运行)
 # 退出码: 0 = 全过, 非 0 = 有失败
@@ -15,14 +21,22 @@ set -u
 cd "$(dirname "$0")/.." || exit 2
 REPO_ROOT="$(pwd)"
 
-PASS=0; FAIL=0
+# 纯库: 无 set -e/trap/副作用, source 进测试进程安全 (B20 守护此契约)。
+# shellcheck source=scripts/build-lib.sh
+. "$REPO_ROOT/scripts/build-lib.sh"
+
+PASS=0; FAIL=0; SKIP=0
 ok()   { echo "  ✅ $1"; PASS=$((PASS+1)); }
 bad()  { echo "  ❌ $1"; FAIL=$((FAIL+1)); }
+skip() { echo "  ⏭️  $1"; SKIP=$((SKIP+1)); }
 scenario() { echo ""; echo "Scenario: $1"; }
 
+# 历史设备基线分支可能已被清理 (issue #8 合并设备分支入 main)。B01/B01b 的
+# "逐字节还原" 比对依赖这些 ref; ref 不在时跳过而非误判失败 —— 拼装契约本身另由
+# B02/B03/B10/B13 (不依赖历史分支) 守护, 还原比对只是分支尚存时的额外保险。
+has_ref() { git rev-parse --verify --quiet "$1" >/dev/null 2>&1; }
+
 ALL_DEVICES="r2s r3s r5s r5s-outdoor r68s x86"
-# 有历史分支可比对原始 .config 的设备 (r3s 是新设备, 无历史基线)
-LEGACY_DEVICES="r2s r5s r5s-outdoor r68s x86"
 # r68s 故意偏离原始 .config: 旧分支符号 friendlyarm_nanopi-r68s 是无效符号
 # (defconfig 静默回退编出 ariaboard_photonicat 废固件), 已修正为上游真实符号
 # lunzn_fastrhino-r68s。故 B01 还原断言豁免 r68s, 由 B13 上游有效性断言守护。
@@ -50,6 +64,10 @@ assemble() { cat config/common.config "devices/$1/seed.config"; }
 # -----------------------------------------------------------------------------
 scenario "B01 — common+seed 逐行还原原始 .config (排除有意新增 CONFIG_CCACHE)"
 for dev in $RESTORE_DEVICES; do
+  if ! has_ref "$dev:.config"; then
+    skip "$dev 基线分支已清理 (ref 不存在), 跳过还原比对"
+    continue
+  fi
   orig=$(git show "$dev:.config" | effective)
   asm=$(assemble "$dev" | effective | grep -v '^CONFIG_CCACHE=y$')
   if diff <(echo "$orig") <(echo "$asm") >/dev/null; then
@@ -62,6 +80,9 @@ done
 scenario "B01b — r68s 有意偏离原始(修正废固件 bug), 仅非符号行应一致"
 # r68s 只有 DEVICE 符号行从 friendlyarm_nanopi-r68s 改为 lunzn_fastrhino-r68s,
 # 其余行应与原始完全一致 (剔除两侧的 r68s DEVICE 符号行与 CCACHE 后比对)
+if ! has_ref "r68s:.config"; then
+  skip "r68s 基线分支已清理 (ref 不存在), 跳过非符号行比对"
+else
 orig_r68s=$(git show "r68s:.config" | effective | grep -vE '_DEVICE_.*r68s=y')
 asm_r68s=$(assemble r68s | effective | grep -v '^CONFIG_CCACHE=y$' | grep -vE '_DEVICE_.*r68s=y')
 if diff <(echo "$orig_r68s") <(echo "$asm_r68s") >/dev/null; then
@@ -69,6 +90,7 @@ if diff <(echo "$orig_r68s") <(echo "$asm_r68s") >/dev/null; then
 else
   bad "r68s 非符号行出现意外漂移:"; diff <(echo "$orig_r68s") <(echo "$asm_r68s")
 fi
+fi  # has_ref r68s
 
 scenario "B02 — 每设备恰好 1 个 DEVICE 符号, 且平台符号唯一"
 for dev in $ALL_DEVICES; do
@@ -195,18 +217,8 @@ fi
 
 # -----------------------------------------------------------------------------
 # 行为 3: matrix 生成逻辑 (B07/B08/B09)
-# 复刻 workflow prepare job 的 set-matrix 逻辑
+# 调 build-lib.sh 的真 gen_matrix 函数 (非复刻; 单一真相源)
 # -----------------------------------------------------------------------------
-gen_matrix() {
-  local DEVICE="$1"
-  local ALL='["r2s","r3s","r5s","r5s-outdoor","r68s","x86"]'
-  if [ -z "$DEVICE" ] || [ "$DEVICE" = "all" ]; then
-    echo "$ALL"
-  else
-    echo "[\"$DEVICE\"]"
-  fi
-}
-
 scenario "B07 — device=all 展开为 6 元素 matrix"
 m=$(gen_matrix all)
 n=$(echo "$m" | jq 'length')
@@ -246,12 +258,13 @@ for dev in $ALL_DEVICES; do
   fi
 done
 
-scenario "B11 — clash 架构探测: x86->amd64, 其余->arm64"
-clash_arch() { grep -q '^CONFIG_TARGET_x86=y' <<<"$(assemble "$1")" && echo amd64 || echo arm64; }
-[ "$(clash_arch x86)" = "amd64" ] && ok "x86 -> amd64" || bad "x86 应为 amd64"
+scenario "B11 — clash 架构探测: x86->amd64, 其余->arm64 (调 build-lib.sh 真函数)"
+# 真函数 clash_arch <config-file> 接文件路径; 把拼装结果落临时文件再喂进去
+arch_of() { local f; f="$(mktemp)"; assemble "$1" > "$f"; clash_arch "$f"; rm -f "$f"; }
+[ "$(arch_of x86)" = "amd64" ] && ok "x86 -> amd64" || bad "x86 应为 amd64"
 fail_arm=0
 for dev in r2s r3s r5s r5s-outdoor r68s; do
-  [ "$(clash_arch "$dev")" = "arm64" ] || { bad "$dev 应为 arm64"; fail_arm=1; }
+  [ "$(arch_of "$dev")" = "arm64" ] || { bad "$dev 应为 arm64"; fail_arm=1; }
 done
 [ "$fail_arm" = "0" ] && ok "r2s/r3s/r5s/r5s-outdoor/r68s -> arm64"
 
@@ -279,17 +292,15 @@ old_n=$(echo "$tags" | jq -r '[.[] | select(.tag_name | startswith("r5s-"))] | l
 
 # -----------------------------------------------------------------------------
 # 行为 6: dl 残包清理只清顶层, 不误删 go-mod-cache 源文件 (B18/B18b)
-# 复刻 workflow "Expand seed config" 步骤里清理小文件的 find, 验证作用域。
+# 调 build-lib.sh 的真 prune_residual_dl 函数 (非复刻; 单一真相源)。
 # 背景: 裸 `find dl -size -1024c -delete` 会递归删进 dl/go-mod-cache/, 把 frp
 # 等 Go 包依赖的合法小 .go 源文件 (如 fatedier/golib/errors/errors.go 800B、
 # pion/dtls types 394B) 当残包误删 -> 离线编译报 "no required module provides
 # package" (run 26865990666 全 6 设备栽在此)。修复: 用 -maxdepth 1 -type f 锁定
 # dl 顶层下载包, 让 go-mod-cache 子树根本不进射程。
 # -----------------------------------------------------------------------------
-# 与 workflow 第 233-234 行同款清理命令 (单一真相源, 改 workflow 时同步改这里)
-prune_dl() { find "$1" -maxdepth 1 -type f -size -1024c -exec rm -f {} \;; }
 
-scenario "B18 — dl 清理删顶层残包, 保住 go-mod-cache 小源文件"
+scenario "B18 — dl 清理删顶层残包, 保住 go-mod-cache 小源文件 (调真函数)"
 DLROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPD" "$DLROOT"' EXIT  # 接管前面 fail-loud 块设的 trap, 一并清理
 mkdir -p "$DLROOT/go-mod-cache/github.com/fatedier/golib/errors"
@@ -297,7 +308,7 @@ mkdir -p "$DLROOT/go-mod-cache/github.com/fatedier/golib/errors"
 printf 'broken\n' > "$DLROOT/some-pkg-1.0.tar.gz"
 # go-mod-cache 里的合法小源文件 (<1024B): 必须保住
 printf 'package errors\n' > "$DLROOT/go-mod-cache/github.com/fatedier/golib/errors/errors.go"
-prune_dl "$DLROOT"
+prune_residual_dl "$DLROOT" >/dev/null 2>&1
 if [ ! -f "$DLROOT/some-pkg-1.0.tar.gz" ] \
    && [ -f "$DLROOT/go-mod-cache/github.com/fatedier/golib/errors/errors.go" ]; then
   ok "顶层残包已删, go-mod-cache 源文件完好 (frp 依赖不再被误删)"
@@ -320,8 +331,140 @@ else
 fi
 rm -rf "$DLROOT2"
 
+# -----------------------------------------------------------------------------
+# 行为 7: build-firmware.sh 抽取契约 (B19-B30) — 反向私有注入支撑
+# 不跑真 make (那是 CI 全量构建的活), 只锁死脚本的接口/防御/路径解析契约。
+# -----------------------------------------------------------------------------
+BF="$REPO_ROOT/scripts/build-firmware.sh"
+GM="$REPO_ROOT/scripts/gen-matrix.sh"
+BL="$REPO_ROOT/scripts/build-lib.sh"
+
+scenario "B19 — 三个新脚本 bash -n 可解析 (无语法错误)"
+synfail=0
+for f in "$BF" "$GM" "$BL"; do
+  bash -n "$f" 2>/dev/null || { bad "$(basename "$f") 语法错误"; synfail=1; }
+done
+[ "$synfail" = "0" ] && ok "build-firmware.sh / gen-matrix.sh / build-lib.sh 均可解析"
+
+scenario "B20 — source build-lib.sh 无副作用 (不开 set -e/不退出/不输出)"
+# 纯库铁律: 被 BDD source 不得带 set -e/trap 污染测试进程, 否则纯函数返回非 0
+# 即杀死整个套件。干净子 shell 里 source, 验证: (1) 未打开 errexit; (2) 无 stdout。
+bl_out="$(bash -c '. "'"$BL"'"; case $- in *e*) echo ERREXIT_ON;; esac' 2>/tmp/bl_err)"
+if [ -z "$bl_out" ] && [ ! -s /tmp/bl_err ]; then
+  ok "build-lib.sh source 后无 errexit 污染、无输出 (可安全被 BDD source)"
+else
+  bad "build-lib.sh source 有副作用: stdout='$bl_out' stderr='$(cat /tmp/bl_err)'"
+fi
+rm -f /tmp/bl_err
+
+scenario "B21 — clash_arch 是 build-lib.sh 导出的真函数 (非 BDD 局部复刻)"
+# 在干净子 shell 里只 source 库, 验证函数确实来自库而非测试文件
+if bash -c '. "'"$BL"'"; declare -F clash_arch >/dev/null && declare -F gen_matrix >/dev/null && declare -F prune_residual_dl >/dev/null && declare -F assemble_config >/dev/null'; then
+  ok "clash_arch/gen_matrix/prune_residual_dl/assemble_config 均由 build-lib.sh 提供"
+else
+  bad "build-lib.sh 未导出预期纯函数"
+fi
+
+scenario "B22 — assemble_config 真函数: common+seed 拼装与 cat 等价"
+# 私有注入的核心契约: assemble_config 就是按序 cat, extra 殿后可覆盖
+a_lib=$(assemble_config config/common.config devices/r5s/seed.config | effective)
+a_cat=$(cat config/common.config devices/r5s/seed.config | effective)
+[ "$a_lib" = "$a_cat" ] && ok "assemble_config == cat (拼装契约不破)" \
+  || bad "assemble_config 与 cat 不等价"
+
+# --- B23-B30: build-firmware.sh 入口防御 (在 make 之前的校验/解析阶段验证) -----
+# 策略: 这些断言都让脚本在 clone/校验阶段就退出 (报错或 --skip-clone 缺目录),
+# 绝不进真 make。用 timeout 兜底防意外卡死。
+runbf() { timeout 30 bash "$BF" "$@"; }
+
+scenario "B23 — 缺 --device 报错退出 (exit!=0)"
+if runbf >/dev/null 2>&1; then
+  bad "缺 --device 竟成功退出 — 强校验失效"
+else
+  ok "缺 --device 非零退出 (内建强校验)"
+fi
+
+scenario "B28 — --device typo 报错退出 (复刻 B13 意图进脚本, 不靠外围 BDD)"
+# 私有 CI 不跑本仓 BDD, 故 typo 防御必须内建在脚本里
+if runbf --device r5x --skip-clone --openwrt-dir /nonexistent >/dev/null 2>&1; then
+  bad "无效设备 r5x 竟通过 — 会编废固件 (重演 r68s 教训)"
+else
+  ok "无效设备 r5x 非零退出 (devices/r5x/seed.config 不存在)"
+fi
+
+scenario "B24 — --skip-clone 时缺 openwrt-dir 即报错, 绝不 clone"
+# --skip-clone 承诺复用已有树; 树不存在应直接失败而非偷偷 clone
+out=$(runbf --device r5s --skip-clone --openwrt-dir /nonexistent-openwrt 2>&1 || true)
+if echo "$out" | grep -q 'does not exist' && ! echo "$out" | grep -qi 'Cloning'; then
+  ok "--skip-clone 缺目录即报错, 未触发 clone"
+else
+  bad "--skip-clone 行为异常: $out"
+fi
+
+scenario "B25 — --extra-config 缺文件即报错 (私有注入支点的存在性校验)"
+if runbf --device r5s --extra-config /no-such-extra.config --skip-clone --openwrt-dir /nonexistent >/dev/null 2>&1; then
+  bad "--extra-config 指向不存在文件竟通过"
+else
+  ok "--extra-config 缺文件非零退出 (注入件丢失会响亮失败, 不静默漏掉)"
+fi
+
+scenario "B26 — assemble_config extra 殿后: 后写覆盖前写 (私有注入可改写 seed)"
+# wizard 包符号注入的核心: extra 拼在 seed 之后, defconfig 取最后一次赋值
+EXTRA="$(mktemp)"
+printf 'CONFIG_PACKAGE_luci-app-mcpe-wizard=y\n' > "$EXTRA"
+merged=$(assemble_config config/common.config devices/r5s/seed.config "$EXTRA")
+last=$(echo "$merged" | tail -n1)
+if [ "$last" = "CONFIG_PACKAGE_luci-app-mcpe-wizard=y" ]; then
+  ok "extra 内容追加在末尾 (defconfig 末值优先 -> 注入可覆盖)"
+else
+  bad "extra 未在末尾, 注入覆盖语义不成立: 末行=$last"
+fi
+rm -f "$EXTRA"
+
+scenario "B27 — hook 路径用 MCPE_REPO_ROOT 绝对路径, cd 子目录后不漂移"
+# 模拟 build-firmware.sh 在 openwrt 目录内执行 diy-part1 时, hook 仍命中 repo 根。
+# 核心: diy-part1.sh 取 \${MCPE_REPO_ROOT:-\$GITHUB_WORKSPACE}, 即使 cwd 变了
+# 绝对路径也不漂移 (旧 \`.\` 兜底会在 cd openwrt 后找错目录静默跳过钩子)。
+sub="$(mktemp -d)"
+hook_path=$(cd "$sub" && MCPE_REPO_ROOT="$REPO_ROOT" DEVICE="r5s-outdoor" bash -c \
+  'echo "${MCPE_REPO_ROOT:-${GITHUB_WORKSPACE:-}}/devices/${DEVICE:-}/pre-feeds.sh"')
+if [ -f "$hook_path" ]; then
+  ok "cd 任意子目录后 hook 路径仍指向 repo 根真实文件 (绝对路径固化)"
+else
+  bad "hook 路径漂移, 找不到文件: $hook_path"
+fi
+rm -rf "$sub"
+
+scenario "B29 — build-vars.env 幂等 (脚本顶部 rm -f, 重跑不堆积)"
+# 校验脚本确实在顶部清理 VARS_OUT。预置脏内容, 跑到校验失败前应已被清空。
+VOUT="$(mktemp)"
+printf 'STALE=garbage\nSTALE2=junk\n' > "$VOUT"
+# 用无效设备让脚本在 rm -f VARS_OUT 之后、make 之前退出; 此时旧内容应已被清掉
+runbf --device r5x --vars-out "$VOUT" --skip-clone --openwrt-dir /nonexistent >/dev/null 2>&1 || true
+if ! grep -q '^STALE=garbage$' "$VOUT" 2>/dev/null; then
+  ok "build-vars.env 启动即清空 (幂等, 旧键不残留)"
+else
+  bad "build-vars.env 未幂等, 残留旧内容: $(cat "$VOUT")"
+fi
+rm -f "$VOUT"
+
+scenario "B30 — 从任意外部 cwd 调用仍正确定位 repo 根 (BASH_SOURCE 硬寻址)"
+# 模拟反向调用: 私有 CI 在自己根目录执行 mCPE-Release/scripts/build-firmware.sh,
+# 不传 --repo-root。脚本须靠 BASH_SOURCE 物理位置 ($SELF_DIR/..) 找到本 repo 根,
+# 而非 $(pwd)(那是私有 repo 根, 会去私有环境找 seed.config 误杀)。
+extcwd="$(mktemp -d)"
+# r5s 有效: 若 repo 根定位正确, 校验通过进入 clone 检查 (--skip-clone 缺目录才退);
+# 报错信息应是 "does not exist"(已过设备校验), 而非 "Invalid device"(repo 根找错)
+out=$(cd "$extcwd" && timeout 30 bash "$BF" --device r5s --skip-clone --openwrt-dir /nonexistent-ow 2>&1 || true)
+if echo "$out" | grep -q 'does not exist' && ! echo "$out" | grep -q 'Invalid device'; then
+  ok "从外部 cwd 调用经 BASH_SOURCE 正确定位 repo 根 (反向调用安全)"
+else
+  bad "外部 cwd 定位 repo 根失败 (可能误用 \$(pwd)): $out"
+fi
+rm -rf "$extcwd"
+
 echo ""
 echo "============================================================"
-echo "BDD 回归结果: PASS=$PASS  FAIL=$FAIL"
+echo "BDD 回归结果: PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP"
 echo "============================================================"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## 概述

把构建编排从 `openwrt-builder.yml`(YAML 不可调用)抽成可复用脚本 `scripts/build-firmware.sh`，使配套私有 repo 能反向 checkout 本 repo → overlay wizard/provision/机密 → 调脚本构建私有镜像。**行为对公开 CI 完全一致**(Never break userspace)。

## 变更

- **脚本分层**(避免 source 污染): `build-lib.sh` 纯库(无 set -e/trap) + `build-firmware.sh` 入口 + `gen-matrix.sh` 薄壳
- **三条绝对防御**(私有 CI 不跑本仓 BDD，守门内建脚本): 设备强校验 / `--skip-clone` 先 git clean / `build-vars.env` 幂等
- **repo 根解析**: `--repo-root` > `$MCPE_REPO_ROOT` > BASH_SOURCE 硬寻址，严禁 `$(pwd)`
- **接缝**: `build-vars.env` + `cat >> $GITHUB_ENV`(GHA 每 step 独立进程不能 source)
- **workflow**: 三 job(lint→prepare→build)，新增 shellcheck/bash -n 护栏
- **BDD**: 删 3 处复刻改测真库函数，新增 B19-B30 抽取契约

## 测试

- 本地 BDD: PASS=54 FAIL=0 SKIP=1
- shellcheck 零警告 + bash -n 全过
- **单设备 r5s 真实 CI 全链路绿**(run 27476009819): 固件命名 `MCPE-251228-04-*friendlyarm_nanopi-r5s*` 与旧 CI 字节级一致，release tag 格式不变

## 阻塞功能

无。diy hook 保留 `GITHUB_WORKSPACE` fallback，旧调用路径不破。

close #14