### PR TITLE
吸收 Copilot review 意见: extra-config 数组化 + BDD 竞态修复

### DIFF
--- a/scripts/build-firmware.sh
+++ b/scripts/build-firmware.sh
@@ -124,8 +124,11 @@ fi
 # --- 2. 拼装 .config (common + seed [+ extra]) + 抽版本三元组 ------------------
 CONFIG_FILE="$OPENWRT_DIR/.config"
 # extra 殿后: 私有注入支点 (wizard 包符号), 后写覆盖前写。
-# shellcheck disable=SC2086  # EXTRA_CONFIG 为单路径或空, 刻意不引号以便空时不传参
-assemble_config "$COMMON" "$SEED" ${EXTRA_CONFIG:+"$EXTRA_CONFIG"} > "$CONFIG_FILE"
+# 用数组显式构造参数: EXTRA_CONFIG 为空时数组不含该元素, 非空时作为独立参数传入,
+# 既无 word-splitting 风险, 也无需 shellcheck disable。
+config_parts=("$COMMON" "$SEED")
+[ -n "$EXTRA_CONFIG" ] && config_parts+=("$EXTRA_CONFIG")
+assemble_config "${config_parts[@]}" > "$CONFIG_FILE"
 echo "Assembled .config for device '$DEVICE' ($(wc -l < "$CONFIG_FILE") lines)"
 
 # 抽版本信息 (在 defconfig 改格式前; emit 到 vars 文件供 CI 重命名固件用)

--- a/tests/bdd-matrix-build.sh
+++ b/tests/bdd-matrix-build.sh
@@ -349,13 +349,14 @@ done
 scenario "B20 — source build-lib.sh 无副作用 (不开 set -e/不退出/不输出)"
 # 纯库铁律: 被 BDD source 不得带 set -e/trap 污染测试进程, 否则纯函数返回非 0
 # 即杀死整个套件。干净子 shell 里 source, 验证: (1) 未打开 errexit; (2) 无 stdout。
-bl_out="$(bash -c '. "'"$BL"'"; case $- in *e*) echo ERREXIT_ON;; esac' 2>/tmp/bl_err)"
-if [ -z "$bl_out" ] && [ ! -s /tmp/bl_err ]; then
+BL_ERR="$(mktemp)"  # 独占临时文件, 避免并行跑回归时的竞态/串扰
+bl_out="$(bash -c '. "'"$BL"'"; case $- in *e*) echo ERREXIT_ON;; esac' 2>"$BL_ERR")"
+if [ -z "$bl_out" ] && [ ! -s "$BL_ERR" ]; then
   ok "build-lib.sh source 后无 errexit 污染、无输出 (可安全被 BDD source)"
 else
-  bad "build-lib.sh source 有副作用: stdout='$bl_out' stderr='$(cat /tmp/bl_err)'"
+  bad "build-lib.sh source 有副作用: stdout='$bl_out' stderr='$(cat "$BL_ERR")'"
 fi
-rm -f /tmp/bl_err
+rm -f "$BL_ERR"
 
 scenario "B21 — clash_arch 是 build-lib.sh 导出的真函数 (非 BDD 局部复刻)"
 # 在干净子 shell 里只 source 库, 验证函数确实来自库而非测试文件


### PR DESCRIPTION
## 概述

PR #15 的 Copilot review follow-up。逐条研判 3 条意见，吸收 2 条、驳回 1 条。

## 吸收

- **build-firmware.sh extra-config 数组化**: 删多余 `shellcheck disable=SC2086` 与自相矛盾的"刻意不引号"注释，改显式数组 `config_parts`（`${VAR:+"$VAR"}` 本无 word-split，disable 是噪声）
- **BDD B20 竞态修复**: stderr 重定向从固定 `/tmp/bl_err` 改 `mktemp`，消除并行跑回归的竞态

## 驳回

- **clone_openwrt 参数顺序**: Copilot 称 `git clone <url> <dir>` 后接 `-b/--depth` 会失败。**实测 exit=0 克隆成功**——git getopt 解析器允许选项与位置参数混排，且与原 workflow 沿用多年的写法一致。驳回。

## 测试

本地 BDD PASS=54 FAIL=0 SKIP=1，shellcheck 零警告，bash -n 全过。