### PR TITLE
升级 GitHub Actions 到 Node 24 运行时 + 钉死漂移版本引用

### DIFF
--- a/.github/workflows/openwrt-builder.yml
+++ b/.github/workflows/openwrt-builder.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.3
       - name: Shellcheck + bash -n
         run: |
           sudo apt-get -qq update && sudo apt-get -qq install shellcheck
@@ -72,7 +72,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.3
       - name: Generate build matrix
         id: set-matrix
         env:
@@ -123,7 +123,7 @@ jobs:
         sudo ln -s /mnt/runner /home/runner
 
     - name: Checkout
-      uses: actions/checkout@main
+      uses: actions/checkout@v6.0.3
 
     - name: Setup Environment and Dependencies
       env:
@@ -172,7 +172,7 @@ jobs:
         ln -sf /workdir/openwrt $GITHUB_WORKSPACE/openwrt
 
     - name: Cache OpenWrt dl & ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v5.0.5
       with:
         # 只缓存 dl(源码包, 跨设备复用) 与 ccache(toolchain 加速)。
         # build_dir/staging_dir 单设备即 15-20GB, 超 GitHub 10GB 全局上限,
@@ -215,7 +215,7 @@ jobs:
       run: df -hT
 
     - name: Upload bin directory
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v7.0.1
       if: steps.compile.outputs.status == 'success' && env.UPLOAD_BIN_DIR == 'true'
       with:
         name: OpenWrt_bin${{ env.DEVICE_NAME }}${{ env.FILE_DATE }}
@@ -263,7 +263,7 @@ jobs:
         echo "status=success" >> $GITHUB_OUTPUT
 
     - name: Upload firmware directory
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v7.0.1
       if: steps.organize.outputs.status == 'success' && !cancelled()
       with:
         name: OpenWrt_firmware${{ env.DEVICE_NAME }}${{ env.FILE_DATE }}
@@ -286,7 +286,7 @@ jobs:
         echo "status=success" >> $GITHUB_OUTPUT
 
     - name: Upload firmware to release
-      uses: softprops/action-gh-release@master
+      uses: softprops/action-gh-release@v3.0.0
       if: steps.tag.outputs.status == 'success' && !cancelled()
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -296,7 +296,7 @@ jobs:
         files: ${{ env.FIRMWARE }}/*
 
     - name: Delete workflow runs
-      uses: Mattraks/delete-workflow-runs@main
+      uses: Mattraks/delete-workflow-runs@v2.1.0
       with:
         retain_days: 0
         keep_minimum_runs: 2


### PR DESCRIPTION
## 概述

GitHub 2026-09-16 起移除 Node 20 运行时，CI 已出 deprecation annotation。升级所有 Node 20 action 到 Node 24 版本，并把 `@main`/`@master` 漂移引用钉成精确 tag。

## 升级（runs.using 字段实证核验）

| Action | 当前 | 升级到 |
|--------|------|--------|
| `actions/checkout` | `@main` | `@v6.0.3` (v4/v5 仍 node20，须跳 v6) |
| `actions/cache` | `@v4` | `@v5.0.5` |
| `actions/upload-artifact` | `@main` | `@v7.0.1` |
| `softprops/action-gh-release` | `@master` | `@v3.0.0` |
| `Mattraks/delete-workflow-runs` | `@main` | `@v2.1.0` |
| `hugoalh/disk-space-optimizer` | `@v0.8.1` | 不动（composite 免疫）|

## 兼容性

- upload-artifact v4→v7 immutable/同名唯一性 breaking change 对本项目无影响：两处 upload name 带 `${DEVICE_NAME}${FILE_DATE}` 后缀，matrix 各设备天然唯一，bin 上传默认关闭。

## 测试

**单设备 r5s 真实 CI 全链路绿**（run 27489671827）：
- 结论 success，全 step ✓
- **Node 20 deprecation annotation 已消失**
- 固件命名 `MCPE-251228-04-*r5s*` 与升级前字节级一致

close #17