### PR TITLE
fix: .config 落位时序回归致业务包静默丢失 (r5s 100MB→28MB)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ main (单分支，承载全部设备)
 │   │   └── pre-feeds.sh          # 设备钩子: 注入 outdoor feed
 │   ├── r68s/seed.config          # NanoPi R68S delta (lunzn_fastrhino)
 │   └── x86/seed.config           # x86_64 + GRUB/EFI/VMDK delta
-└── tests/bdd-matrix-build.sh     # 55条 BDD 断言回归套件
+└── tests/bdd-matrix-build.sh     # 56条 BDD 断言回归套件
 ```
 
 ### 种子配置架构
@@ -134,14 +134,16 @@ DEVICE: ${{ matrix.device }}  # build job 级注入，全 step 可见
 ```
 [CI 基础设施] 磁盘优化 → checkout → 装依赖 → clone ImmortalWRT 到 /workdir (夹住 cache action)
 [scripts/build-firmware.sh --skip-clone] 构建核心:
-  拼装种子(common+seed) → 抽版本三元组 → diy-part1(feeds+pre-feeds钩子)
-  → feeds update/install → diy-part2(系统配置+post-feeds钩子)
+  拼装种子到 staging(common+seed, openwrt树外) → 抽版本三元组 → diy-part1(feeds+pre-feeds钩子)
+  → feeds update/install → .config 落位(staging→openwrt/.config, 必须在feeds install后)
+  → diy-part2(系统配置+post-feeds钩子)
   → defconfig 展开 → make download → 清残包(prune_residual_dl)
   → 预置 clash 核心 → make → 抽设备名 → emit build-vars.env
 [CI 基础设施] cat build-vars.env >> $GITHUB_ENV (跨 step 桥接)
   → 重命名固件(MCPE-251228-NN-*) → 上传 Release → 清理旧 Release
 ```
-> 构建核心收敛进 `scripts/build-firmware.sh`（脚本分层/接口/三条绝对防御/私有反向 checkout 用法见 [docs/build-firmware-script.md](docs/build-firmware-script.md)）。CI 自行 clone 以夹住 cache action，故走 `--skip-clone`；私有 repo 反向调用时不传该参数让脚本自 clone。
+> 构建核心收敛进 `scripts/build-firmware.sh`（脚本分层/接口/四条绝对防御/私有反向 checkout 用法见 [docs/build-firmware-script.md](docs/build-firmware-script.md)）。CI 自行 clone 以夹住 cache action，故走 `--skip-clone`；私有 repo 反向调用时不传该参数让脚本自 clone。
+> ⚠️ 时序铁律：`.config` 落位 openwrt 树必须在 `feeds install` 之后。若在 feeds install 前 .config 已存在，install 触发的 Kconfig 扫描会把 feed 包符号（openclash/docker/frpc 等）静默重置为 not-set，编出瘦固件（历史回归：r5s 100MB→28MB）。BDD B31 守护此契约。
 
 ## 定制配置
 
@@ -251,7 +253,7 @@ git push   # 单分支直接推，无需同步多分支
 ### 配置验证
 改动 config/devices 后跑本地回归，确认拼装契约与上游符号有效性不破：
 ```bash
-bash tests/bdd-matrix-build.sh   # 55 条断言，含拼装等价性 + 上游符号白名单 + fail-loud 原语 + dl 清理作用域 + build-firmware.sh 抽取契约(B19-B30)
+bash tests/bdd-matrix-build.sh   # 56 条断言，含拼装等价性 + 上游符号白名单 + fail-loud 原语 + dl 清理作用域 + build-firmware.sh 抽取契约(B19-B31, 含 .config 落位时序)
 ```
 
 ## 安全规范
@@ -276,7 +278,7 @@ git commit -m "fix: resolve build error, close #1"
 ## 参考资源
 
 ### 技术文档（docs/）
-- [docs/build-firmware-script.md](docs/build-firmware-script.md) — `scripts/build-firmware.sh` 构建编排脚本契约（脚本分层/参数/三条绝对防御/接缝设计）+ 私有 repo 反向 checkout 注入私有镜像的完整用法
+- [docs/build-firmware-script.md](docs/build-firmware-script.md) — `scripts/build-firmware.sh` 构建编排脚本契约（脚本分层/参数/四条绝对防御/接缝设计）+ 私有 repo 反向 checkout 注入私有镜像的完整用法
 - [docs/rust-ci-llvm-404-fix.md](docs/rust-ci-llvm-404-fix.md) — rust [host] 编译 CI LLVM 404 的根因/临时 patch/升级根治方向（v24.10.4 feed pin 锁死 rust 1.89.0）
 - [docs/uwsgi-gcc-fix-journey.md](docs/uwsgi-gcc-fix-journey.md) — uwsgi 包 GCC 编译错误排查记录
 

--- a/docs/build-firmware-script.md
+++ b/docs/build-firmware-script.md
@@ -54,7 +54,7 @@ scripts/
 
 ---
 
-## 三条绝对防御
+## 四条绝对防御
 
 私有 CI 不跑本仓 BDD 套件，脚本内部必须内建守门逻辑，不能依赖外部测试保障。
 
@@ -84,6 +84,19 @@ emit() { printf '%s=%s\n' "$1" "$2" >> "$VARS_OUT"; }
 ```
 
 **为何**：脚本在任何校验/退出之前就清空 vars 文件，包括早期 exit 路径。若不清，多轮调试下旧 KEY 残留堆积，`cat >> $GITHUB_ENV` 会把过期值（如上次的 `VERSION_CODE`）灌进当前 step，排查时极难定位。即使校验失败，留下的也是干净（空）文件而非垃圾堆。
+
+### 防御 4：`.config` 落位必须在 `feeds install` 之后
+
+```bash
+# 拼装阶段: 拼到 openwrt 树外的 staging, 绝不直写 $OPENWRT_DIR/.config
+STAGED_CONFIG="$(mktemp)"
+assemble_config "${config_parts[@]}" > "$STAGED_CONFIG"
+# ... diy-part1 → feeds update → feeds install ...
+# feeds install 完成后才落位
+cp "$STAGED_CONFIG" "$OPENWRT_DIR/.config"
+```
+
+**为何**：OpenWrt 的 `./scripts/feeds install -a` 若发现 `openwrt/.config` 已存在，会触发 Kconfig 扫描，而此刻 `package/feeds/` symlink 尚未建全——来自 luci/packages feed 的包符号（`CONFIG_PACKAGE_luci-app-openclash` / `dockerd` / `frpc` 等）被当作未知符号**静默重置为 not-set**，整套业务包无声蒸发，编出近乎默认的瘦固件。这是一次真实回归：脚本重构初版把 `.config` 在拼装阶段直写进 openwrt 树，导致 r5s 固件从 100+MB 暴跌到 28MB、`config.buildinfo` 仅剩 13 行（只含 seed 的 target 项 + 被依赖自动拉入的几个包）。旧 workflow 一直是「先拼到 workspace、`feeds install` 后再 `mv` 进 openwrt」的时序，本脚本必须复刻。版本三元组的抽取从 staging 文件早读，不受落位时序影响。BDD `B31` 静态守护此时序契约（落位行号必须 > `feeds install` 行号，且拼装阶段不得直写 openwrt 树）。
 
 ---
 

--- a/scripts/build-firmware.sh
+++ b/scripts/build-firmware.sh
@@ -121,20 +121,28 @@ else
   clone_openwrt "$REPO_URL" "$REPO_BRANCH" "$TAG" "$OPENWRT_DIR"
 fi
 
-# --- 2. 拼装 .config (common + seed [+ extra]) + 抽版本三元组 ------------------
-CONFIG_FILE="$OPENWRT_DIR/.config"
+# --- 2. 拼装 .config 到 staging (openwrt 树外) + 抽版本三元组 ------------------
+# 时序铁律: .config 绝不可在 feeds install 之前进 openwrt/。OpenWrt 的
+# `./scripts/feeds install -a` 若发现 openwrt/.config 已存在, 会触发 Kconfig 扫描,
+# 而此刻 package/feeds/ symlink 尚未建全 —— 来自 luci/packages feed 的包符号
+# (CONFIG_PACKAGE_luci-app-openclash / dockerd / frpc ...) 被当未知符号静默重置为
+# not-set, 整套业务包无声蒸发, 编出近乎默认的瘦固件 (回归实例: 100MB->28MB,
+# config.buildinfo 仅剩 13 行)。故先拼到 openwrt 树外的 staging, 待 feeds install
+# 完成后 (第 4.5 步) 才落位。BDD B31 守护此时序契约。
+STAGED_CONFIG="$(mktemp)"
+trap 'rm -f "${STAGED_CONFIG:-}"' EXIT
 # extra 殿后: 私有注入支点 (wizard 包符号), 后写覆盖前写。
 # 用数组显式构造参数: EXTRA_CONFIG 为空时数组不含该元素, 非空时作为独立参数传入,
 # 既无 word-splitting 风险, 也无需 shellcheck disable。
 config_parts=("$COMMON" "$SEED")
 [ -n "$EXTRA_CONFIG" ] && config_parts+=("$EXTRA_CONFIG")
-assemble_config "${config_parts[@]}" > "$CONFIG_FILE"
-echo "Assembled .config for device '$DEVICE' ($(wc -l < "$CONFIG_FILE") lines)"
+assemble_config "${config_parts[@]}" > "$STAGED_CONFIG"
+echo "Assembled seed .config for '$DEVICE' ($(wc -l < "$STAGED_CONFIG") lines, staged outside openwrt tree)"
 
-# 抽版本信息 (在 defconfig 改格式前; emit 到 vars 文件供 CI 重命名固件用)
-VERSION_DIST=$(grep 'CONFIG_VERSION_DIST=' "$CONFIG_FILE" | cut -d'"' -f2)
-VERSION_NUMBER=$(grep 'CONFIG_VERSION_NUMBER=' "$CONFIG_FILE" | cut -d'"' -f2)
-VERSION_CODE=$(grep 'CONFIG_VERSION_CODE=' "$CONFIG_FILE" | cut -d'"' -f2)
+# 抽版本信息 (在 defconfig 改格式前; 从 staging 早抽, 不受落位时序影响)
+VERSION_DIST=$(grep 'CONFIG_VERSION_DIST=' "$STAGED_CONFIG" | cut -d'"' -f2)
+VERSION_NUMBER=$(grep 'CONFIG_VERSION_NUMBER=' "$STAGED_CONFIG" | cut -d'"' -f2)
+VERSION_CODE=$(grep 'CONFIG_VERSION_CODE=' "$STAGED_CONFIG" | cut -d'"' -f2)
 emit VERSION_DIST "$VERSION_DIST"
 emit VERSION_NUMBER "$VERSION_NUMBER"
 emit VERSION_CODE "$VERSION_CODE"
@@ -164,6 +172,13 @@ chmod +x "$MCPE_REPO_ROOT/diy-part1.sh"
 
 # --- 4. feeds update + install ------------------------------------------------
 ( cd "$OPENWRT_DIR" && ./scripts/feeds update -a && ./scripts/feeds install -a )
+
+# --- 4.5 staged .config 落位 (feeds install 之后, 与旧 workflow 时序一致) -------
+# 至此 package/feeds/ symlink 已建全, 落位后 defconfig 能正确解析所有 feed 包符号。
+# 这一步绝不可提前到 feeds install 之前 (见第 2 步时序铁律说明)。
+CONFIG_FILE="$OPENWRT_DIR/.config"
+cp "$STAGED_CONFIG" "$CONFIG_FILE"
+echo "Placed .config into openwrt tree after feeds install ($(wc -l < "$CONFIG_FILE") lines)"
 
 # --- 5. diy-part2 (系统配置 + 设备 post-feeds 钩子) ----------------------------
 # files/ overlay: 私有注入把 provision.sh+templates 放 $MCPE_REPO_ROOT/files/,

--- a/tests/bdd-matrix-build.sh
+++ b/tests/bdd-matrix-build.sh
@@ -9,7 +9,7 @@
 #   4. 固件命名前缀 & 架构探测 & release 隔离 (B10/B11/B12)
 #   5. fail-loud 定制原语 (B15/B16/B17)
 #   6. dl 残包清理作用域 (B18/B18b) — 调 build-lib.sh 真函数
-#   7. build-firmware.sh 抽取契约 (B19-B30) — 反向私有注入支撑
+#   7. build-firmware.sh 抽取契约 (B19-B31) — 反向私有注入支撑 + .config 落位时序
 #
 # 单一真相源: B07-B09/B11/B18 测的是 scripts/build-lib.sh 的真函数 (非复刻),
 #   改一处不必同步两处。
@@ -332,7 +332,7 @@ fi
 rm -rf "$DLROOT2"
 
 # -----------------------------------------------------------------------------
-# 行为 7: build-firmware.sh 抽取契约 (B19-B30) — 反向私有注入支撑
+# 行为 7: build-firmware.sh 抽取契约 (B19-B31) — 反向私有注入支撑 + 落位时序
 # 不跑真 make (那是 CI 全量构建的活), 只锁死脚本的接口/防御/路径解析契约。
 # -----------------------------------------------------------------------------
 BF="$REPO_ROOT/scripts/build-firmware.sh"
@@ -463,6 +463,32 @@ else
   bad "外部 cwd 定位 repo 根失败 (可能误用 \$(pwd)): $out"
 fi
 rm -rf "$extcwd"
+
+scenario "B31 — .config 落位 openwrt 树必须在 feeds install 之后 (防瘦固件回归)"
+# 回归背景: build-firmware.sh 重构曾把 .config 直接写 \$OPENWRT_DIR/.config 于拼装
+# 阶段 (feeds install 之前)。OpenWrt 的 \`feeds install -a\` 见 openwrt/.config 已存
+# 在即触发 Kconfig 扫描, 而此刻 package/feeds/ symlink 未建全, 来自 luci/packages
+# feed 的包符号 (openclash/dockerd/frpc...) 被当未知符号静默重置为 not-set, 整套
+# 业务包无声蒸发 -> 固件 100MB 暴跌 28MB, config.buildinfo 仅剩 13 行。
+# 修复: 拼到 openwrt 树外 staging, feeds install 完成后才 cp 落位。
+# 本断言静态守护此时序: 落位行 (cp ... 到 \$OPENWRT_DIR/.config) 必须在
+# feeds install 之后, 且拼装阶段不得把 assemble_config 直接重定向进 openwrt 树。
+# grep 取实际命令行: 排除注释行 (行首去空格后为 #), 否则会误命中第 2 步注释里
+# 解释时序铁律时提及的 \`./scripts/feeds install -a\` 文字。
+cmd_lines() { grep -nE "$1" "$BF" | grep -vE '^[0-9]+:[[:space:]]*#'; }
+feeds_ln=$(cmd_lines 'feeds install -a' | head -n1 | cut -d: -f1)
+place_ln=$(cmd_lines 'cp "\$STAGED_CONFIG" "\$CONFIG_FILE"' | head -n1 | cut -d: -f1)
+asm_ln=$(cmd_lines 'assemble_config .* > "\$STAGED_CONFIG"' | head -n1 | cut -d: -f1)
+# 拼装阶段不得直接写 openwrt 树: assemble_config 的重定向目标必须是 staging, 不是
+# \$OPENWRT_DIR/.config / \$CONFIG_FILE (后者只应出现在 feeds install 之后的落位行)。
+asm_to_tree=$(cmd_lines 'assemble_config .* > "(\$OPENWRT_DIR/\.config|\$CONFIG_FILE)"' || true)
+if [ -n "$feeds_ln" ] && [ -n "$place_ln" ] && [ -n "$asm_ln" ] \
+   && [ "$place_ln" -gt "$feeds_ln" ] && [ "$asm_ln" -lt "$feeds_ln" ] \
+   && [ -z "$asm_to_tree" ]; then
+  ok "拼装(行$asm_ln)→feeds install(行$feeds_ln)→落位(行$place_ln): 时序正确, 拼装不直写 openwrt 树"
+else
+  bad "时序契约破坏: 拼装行=$asm_ln feeds行=$feeds_ln 落位行=$place_ln 直写树=${asm_to_tree:-无} (落位须>feeds, 拼装须<feeds且写 staging)"
+fi
 
 echo ""
 echo "============================================================"


### PR DESCRIPTION
## 问题

构建编排抽取为 `scripts/build-firmware.sh`（#14, commit 5d962ec）后，r5s 固件从 100+MB 暴跌到 28MB，openclash/docker/frpc 等整套业务包静默丢失。

## 根因

重构初版把拼装好的 `.config` 在拼装阶段就直写进 `$OPENWRT_DIR/.config`（`feeds install` 之前）。OpenWrt 的 `feeds install -a` 见 `openwrt/.config` 已存在即触发 Kconfig 扫描，而此刻 `package/feeds/` symlink 尚未建全——来自 luci/packages feed 的包符号被当未知符号静默重置为 not-set，business 包无声蒸发。

旧 workflow 一直是「拼到 workspace（openwrt 树外）→ feeds install → 再 mv 进 openwrt」的时序，重构破坏了这个不变量。bisect 干净：5d962ec 前包齐全，后三次构建全是 13 行 config.buildinfo / 27MB。

## 修复

复刻旧 workflow 的 proven 时序：拼装写入 openwrt 树外 staging 临时文件，`feeds install` 完成后才 `cp` 落位。版本三元组从 staging 早抽。

| 文件 | 变更 |
|------|------|
| `scripts/build-firmware.sh` | `STAGED_CONFIG`(mktemp) + 第 4.5 步 feeds install 后落位 |
| `tests/bdd-matrix-build.sh` | 新增 B31 守护落位时序契约（56 条断言） |
| `docs/build-firmware-script.md` | 新增「防御 4：.config 落位必须在 feeds install 之后」 |
| `CLAUDE.md` | 修正构建流程示意 + 时序铁律 |

## 测试

- 本地 BDD 全过：`PASS=56 FAIL=0`
- B31 负向验证：坏时序变红、正确时序变绿
- shellcheck + `bash -n` 干净
- 合并后需 CI 全量构建 r5s 验证出回 100+MB 固件

fix #21
