### PR TITLE
test: --skip-make 时序验证探针 + 临时验证 workflow

### DIFF
--- a/.github/workflows/verify-config-timing.yml
+++ b/.github/workflows/verify-config-timing.yml
@@ -1,0 +1,104 @@
+#
+# 临时验证 workflow — 验证 build-firmware.sh 的 .config 落位时序修复 (issue #21)
+#
+# 命题: 修复后 .config 在 feeds install 之后落位, common.config 的 feed 包符号
+#       (openclash/docker/frpc...) 在 defconfig 展开后存活。
+# 手段: 调 build-firmware.sh --skip-make, 跑到 defconfig 即停 dump 包统计, 不进真
+#       编译 (几分钟 vs 全量 make 1-2 小时)。验证通过后本 workflow 应删除。
+#
+name: Verify Config Timing
+
+on:
+  workflow_dispatch:
+    inputs:
+      device:
+        description: 'Device to verify'
+        required: true
+        type: choice
+        default: 'r5s'
+        options:
+          - r5s
+          - r2s
+          - r3s
+          - r5s-outdoor
+          - r68s
+          - x86
+      openwrt_tag:
+        description: 'ImmortalWRT tag'
+        required: false
+        default: 'v24.10.6'
+
+env:
+  REPO_URL: https://github.com/immortalwrt/immortalwrt
+  REPO_BRANCH: openwrt-24.10
+  OPENWRT_TAG: ${{ github.event.inputs.openwrt_tag }}
+  TZ: Asia/Shanghai
+
+jobs:
+  verify:
+    runs-on: ubuntu-22.04
+    env:
+      DEVICE: ${{ github.event.inputs.device }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+
+      - name: Setup dependencies (feeds 工具链所需最小集)
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo -E apt-get -qq update
+          sudo -E apt-get -qq install build-essential clang flex bison g++ gawk \
+            gcc-multilib g++-multilib gettext git libncurses5-dev libssl-dev \
+            python3-setuptools rsync swig unzip zlib1g-dev file wget
+          sudo timedatectl set-timezone "$TZ"
+
+      - name: Clone openwrt source code
+        run: |
+          git clone "$REPO_URL" -b "$REPO_BRANCH" openwrt --depth=1
+          cd openwrt
+          if [ -n "$OPENWRT_TAG" ]; then
+            git fetch --depth=1 origin tag "$OPENWRT_TAG"
+            git checkout "tags/$OPENWRT_TAG"
+          fi
+
+      - name: Run build-firmware.sh --skip-make (timing probe)
+        run: |
+          chmod +x scripts/build-firmware.sh
+          scripts/build-firmware.sh \
+            --device "$DEVICE" \
+            --tag "$OPENWRT_TAG" \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --openwrt-dir "$GITHUB_WORKSPACE/openwrt" \
+            --skip-clone \
+            --skip-make \
+            --vars-out "$GITHUB_WORKSPACE/verify-vars.env"
+
+      - name: Assert feed packages survived defconfig
+        run: |
+          # 落位时序正确时这些 feed 包符号应在展开后的 .config 里存活。
+          # 时序错误 (回归) 时它们被 Kconfig 静默重置, 断言失败。
+          cd "$GITHUB_WORKSPACE/openwrt"
+          fail=0
+          check() {
+            if grep -q "^CONFIG_PACKAGE_$1=y" .config; then
+              echo "  ✅ $1 selected"
+            else
+              echo "  ❌ $1 MISSING (落位时序回归!)"; fail=1
+            fi
+          }
+          echo "=== Feed 包符号存活断言 ==="
+          check luci-app-openclash
+          check dockerd
+          check docker
+          check luci-app-frpc
+          check htop
+          check iperf3
+          n=$(grep -c '^CONFIG_PACKAGE_.*=y' .config)
+          echo "=== 选中包总数: $n (修复前坏值约 buildinfo 13 行; 期望 >150) ==="
+          if [ "$n" -lt 150 ]; then
+            echo "  ❌ 选中包数 $n < 150, 业务包大批丢失 (回归未修复)"; fail=1
+          else
+            echo "  ✅ 选中包数 $n >= 150 (业务包齐备)"
+          fi
+          exit "$fail"

--- a/scripts/build-firmware.sh
+++ b/scripts/build-firmware.sh
@@ -20,7 +20,11 @@
 # 用法:
 #   scripts/build-firmware.sh --device <dev> [--tag v24.10.6] [--repo-root .]
 #     [--openwrt-dir ./openwrt] [--extra-config <f>] [--vars-out build-vars.env]
-#     [--skip-clone]
+#     [--skip-clone] [--skip-make]
+#
+# --skip-make: 跑到 `make defconfig` 展开后即停, dump 选中包统计 (CONFIG_PACKAGE_*=y
+#   数量 + openclash/docker/frpc 探针) 并退出, 不进真编译。用于快速验证 .config 落位
+#   时序契约 (几分钟 vs 全量 make 的 1-2 小时), 私有 CI 也可用它 dry-run 验注入包符号。
 # =============================================================================
 set -euo pipefail
 trap 'echo "ERROR: build-firmware.sh failed (line $LINENO, exit $?)" >&2' ERR
@@ -41,9 +45,10 @@ OPENWRT_DIR="./openwrt"
 EXTRA_CONFIG=""
 VARS_OUT="build-vars.env"
 SKIP_CLONE=0
+SKIP_MAKE=0
 
 usage() {
-  sed -n '2,27p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,31p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 # abspath <path>: 解析为绝对路径, 即使路径尚不存在 (取父目录 + basename)。
@@ -66,6 +71,7 @@ while [ $# -gt 0 ]; do
     --extra-config) EXTRA_CONFIG="$2"; shift 2 ;;
     --vars-out)     VARS_OUT="$2"; shift 2 ;;
     --skip-clone)   SKIP_CLONE=1; shift ;;
+    --skip-make)    SKIP_MAKE=1; shift ;;
     -h|--help)      usage; exit 0 ;;
     *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -196,8 +202,25 @@ chmod +x "$MCPE_REPO_ROOT/diy-part2.sh"
   echo "Expanding seed config with make defconfig..."
   make defconfig
   echo "Full config lines: $(wc -l < .config)"
+  # 时序验证探针: defconfig 展开后选中的 CONFIG_PACKAGE_*=y 数量。落位时序正确时
+  # common.config 的 feed 包符号 (openclash/docker/frpc...) 在此存活, 数量应 ~200+;
+  # 时序错误时这些符号被 Kconfig 静默重置, 数量塌缩到几十 (回归实例 13 行 buildinfo)。
+  echo "Selected packages (CONFIG_PACKAGE_*=y): $(grep -c '^CONFIG_PACKAGE_.*=y' .config)"
+  echo "Probe: openclash=$(grep -c '^CONFIG_PACKAGE_luci-app-openclash=y' .config) dockerd=$(grep -c '^CONFIG_PACKAGE_dockerd=y' .config) frpc=$(grep -c '^CONFIG_PACKAGE_luci-app-frpc=y' .config)"
+  if [ "$SKIP_MAKE" -eq 1 ]; then
+    echo "==> --skip-make: stopping after defconfig (timing verification dry-run, no real build)"
+    exit 0
+  fi
   make download -j8
 )
+# --skip-make 时上面子 shell 的 exit 0 只退出子 shell, 主脚本需在此显式短路返回。
+if [ "$SKIP_MAKE" -eq 1 ]; then
+  emit FULL_CONFIG_LINES "$(wc -l < "$OPENWRT_DIR/.config")"
+  emit SELECTED_PACKAGES "$(grep -c '^CONFIG_PACKAGE_.*=y' "$OPENWRT_DIR/.config")"
+  emit BUILD_STATUS skipped
+  echo "==> build-firmware: --skip-make done (defconfig-only). vars written to $VARS_OUT"
+  exit 0
+fi
 prune_residual_dl "$OPENWRT_DIR/dl"
 
 # --- 7. 预置 clash 核心 + GeoIP/GeoSite ---------------------------------------


### PR DESCRIPTION
## 目的

快速验证 #21 的 .config 落位时序修复是否真生效，无需等全量 make（1-2 小时）。

## 变更

- **`scripts/build-firmware.sh` 加 `--skip-make`**：跑到 `make defconfig` 展开后即停，dump 选中包统计（`CONFIG_PACKAGE_*=y` 数 + openclash/docker/frpc 探针）并退出，不进真编译。这是脚本的长期能力增强——私有 CI 也可用它 dry-run 验证注入的 wizard 包符号是否被 defconfig 保留，几分钟出结果。
- **`.github/workflows/verify-config-timing.yml`**（临时）：clone openwrt 后调脚本 `--skip-make`，断言 openclash/docker/frpc 等 feed 包符号在 defconfig 后存活、选中包总数 >=150。**验证通过后单独 PR 删除本 workflow。**

## 为何要合进 main

GitHub `workflow_dispatch` 要求 workflow 文件先存在于默认分支才能触发。合并后即可 `gh workflow run verify-config-timing.yml -f device=r5s`。

## 测试

- 本地 BDD 全过：`PASS=55 FAIL=0`（B31 行号自动跟进，时序契约不破）
- shellcheck + `bash -n` 干净
