### PR TITLE
fix: 补 CONFIG_DEVEL=y 修复 ccache 全程空转 (#25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ main (单分支，承载全部设备)
 │   │   └── pre-feeds.sh          # 设备钩子: 注入 outdoor feed
 │   ├── r68s/seed.config          # NanoPi R68S delta (lunzn_fastrhino)
 │   └── x86/seed.config           # x86_64 + GRUB/EFI/VMDK delta
-└── tests/bdd-matrix-build.sh     # 56条 BDD 断言回归套件
+└── tests/bdd-matrix-build.sh     # 57条 BDD 断言回归套件
 ```
 
 ### 种子配置架构
@@ -119,7 +119,7 @@ main (单分支，承载全部设备)
 - **构建编排抽取**: build job 的构建核心已抽成可复用脚本 `scripts/build-firmware.sh`，CI 与私有 repo 反向 checkout 共用单一真相源，详见 [docs/build-firmware-script.md](docs/build-firmware-script.md)
 - **源码管理**: 基于tag checkout（默认v24.10.6），支持手动指定
 - **架构探测**: Clash 核心按 `grep CONFIG_TARGET_x86` 选 amd64/arm64（不依赖分支名）
-- **缓存策略**: 只缓存 `dl`（源码包跨设备复用）+ `ccache`，不缓存 build_dir/staging_dir（单设备即超 10GB 全局上限，会触发 LRU 雪崩）
+- **缓存策略**: 只缓存 `dl`（源码包跨设备复用）+ `ccache`，不缓存 build_dir/staging_dir（单设备即超 10GB 全局上限，会触发 LRU 雪崩）。⚠️ ccache 契约：`common.config` 须同时声明 `CONFIG_DEVEL=y` + `CONFIG_CCACHE=y`——上游 CCACHE 的 prompt 是 `bool "Use ccache" if DEVEL`，缺 DEVEL 则 `make defconfig` 静默剔除 CCACHE，ccache 全程空转、缓存恒空（历史 bug：issue #25）。BDD B03b 守护此防呆。
 - **Release**: Tag格式`{设备名}-YYYY.MM.DD-HHMM`，每设备保留2个；清理用 date-anchored 正则隔离 + 退避重试防限流
 
 **环境变量**：
@@ -253,7 +253,7 @@ git push   # 单分支直接推，无需同步多分支
 ### 配置验证
 改动 config/devices 后跑本地回归，确认拼装契约与上游符号有效性不破：
 ```bash
-bash tests/bdd-matrix-build.sh   # 56 条断言，含拼装等价性 + 上游符号白名单 + fail-loud 原语 + dl 清理作用域 + build-firmware.sh 抽取契约(B19-B31, 含 .config 落位时序)
+bash tests/bdd-matrix-build.sh   # 57 条断言，含拼装等价性 + 上游符号白名单 + fail-loud 原语 + dl 清理作用域 + build-firmware.sh 抽取契约(B19-B31, 含 .config 落位时序) + ccache DEVEL 依赖防呆(B03b)
 ```
 
 ## 安全规范

--- a/config/common.config
+++ b/config/common.config
@@ -16,6 +16,9 @@ CONFIG_TARGET_ROOTFS_SQUASHFS=y
 CONFIG_TARGET_KERNEL_PARTSIZE=32
 CONFIG_TARGET_ROOTFS_PARTSIZE=1024
 
+# Kernel Security
+CONFIG_KERNEL_SECURITY_LANDLOCK=y
+
 # Build Acceleration (host-side ccache; arch-neutral, 不影响固件内容)
 # CONFIG_DEVEL 必须置顶: 上游 config/Config-devel.in 把 CCACHE 的 prompt 声明为
 # `bool "Use ccache" if DEVEL`, DEVEL 关闭时 CCACHE prompt 不可见, make defconfig

--- a/config/common.config
+++ b/config/common.config
@@ -17,6 +17,11 @@ CONFIG_TARGET_KERNEL_PARTSIZE=32
 CONFIG_TARGET_ROOTFS_PARTSIZE=1024
 
 # Build Acceleration (host-side ccache; arch-neutral, 不影响固件内容)
+# CONFIG_DEVEL 必须置顶: 上游 config/Config-devel.in 把 CCACHE 的 prompt 声明为
+# `bool "Use ccache" if DEVEL`, DEVEL 关闭时 CCACHE prompt 不可见, make defconfig
+# 会静默剔除 CONFIG_CCACHE=y 回退默认 n, 导致 ccache 全程空转(详见 issue #25)。
+# DEVEL 仅解锁 host 侧开发者选项可见性, arch-neutral, 不改变固件内容。
+CONFIG_DEVEL=y
 CONFIG_CCACHE=y
 
 # Firmware Version (公共部分; VERSION_CODE / VERSION_HWREV 在各设备 seed 内)

--- a/tests/bdd-matrix-build.sh
+++ b/tests/bdd-matrix-build.sh
@@ -62,14 +62,14 @@ assemble() { cat config/common.config "devices/$1/seed.config"; }
 # -----------------------------------------------------------------------------
 # 行为 1: 拼装等价性 (B01/B02/B03)
 # -----------------------------------------------------------------------------
-scenario "B01 — common+seed 逐行还原原始 .config (排除有意新增 CONFIG_CCACHE)"
+scenario "B01 — common+seed 逐行还原原始 .config (排除有意新增 CONFIG_CCACHE/CONFIG_DEVEL)"
 for dev in $RESTORE_DEVICES; do
   if ! has_ref "$dev:.config"; then
     skip "$dev 基线分支已清理 (ref 不存在), 跳过还原比对"
     continue
   fi
   orig=$(git show "$dev:.config" | effective)
-  asm=$(assemble "$dev" | effective | grep -v '^CONFIG_CCACHE=y$')
+  asm=$(assemble "$dev" | effective | grep -vE '^CONFIG_(CCACHE|DEVEL)=y$')
   if diff <(echo "$orig") <(echo "$asm") >/dev/null; then
     ok "$dev 还原一致"
   else
@@ -79,12 +79,12 @@ done
 
 scenario "B01b — r68s 有意偏离原始(修正废固件 bug), 仅非符号行应一致"
 # r68s 只有 DEVICE 符号行从 friendlyarm_nanopi-r68s 改为 lunzn_fastrhino-r68s,
-# 其余行应与原始完全一致 (剔除两侧的 r68s DEVICE 符号行与 CCACHE 后比对)
+# 其余行应与原始完全一致 (剔除两侧的 r68s DEVICE 符号行与 CCACHE/DEVEL 后比对)
 if ! has_ref "r68s:.config"; then
   skip "r68s 基线分支已清理 (ref 不存在), 跳过非符号行比对"
 else
 orig_r68s=$(git show "r68s:.config" | effective | grep -vE '_DEVICE_.*r68s=y')
-asm_r68s=$(assemble r68s | effective | grep -v '^CONFIG_CCACHE=y$' | grep -vE '_DEVICE_.*r68s=y')
+asm_r68s=$(assemble r68s | effective | grep -vE '^CONFIG_(CCACHE|DEVEL)=y$' | grep -vE '_DEVICE_.*r68s=y')
 if diff <(echo "$orig_r68s") <(echo "$asm_r68s") >/dev/null; then
   ok "r68s 除 DEVICE 符号修正外其余完全一致"
 else
@@ -113,6 +113,21 @@ if [ -z "$poison" ]; then
   ok "common.config 架构中立 (无平台根符号/DEVICE/GRUB/VMDK)"
 else
   bad "common.config 混入架构项:"; echo "$poison"
+fi
+
+scenario "B03b — ccache 防呆: CONFIG_CCACHE=y 必须伴随 CONFIG_DEVEL=y (issue #25)"
+# 局限声明: 这是纯文本共现的低级防呆正则, 不跑 make defconfig, 不验 Kconfig 解析
+# 顺序或跨文件覆盖。仅拦"有人单独删掉 DEVEL"的低级回归 —— 上游 CCACHE 的 prompt
+# 是 `bool "Use ccache" if DEVEL`, 缺 DEVEL 则 defconfig 静默剔除 CCACHE 致 ccache
+# 全程空转。ccache 是否真激活由真实 CI 构建兜底, 此处只守"两行同在 common.config"。
+has_ccache=$(grep -qxF 'CONFIG_CCACHE=y' config/common.config && echo y || echo n)
+has_devel=$(grep -qxF 'CONFIG_DEVEL=y' config/common.config && echo y || echo n)
+if [ "$has_ccache" = n ]; then
+  ok "common.config 未启用 CONFIG_CCACHE (无 DEVEL 依赖约束)"
+elif [ "$has_devel" = y ]; then
+  ok "CONFIG_CCACHE=y 已伴随 CONFIG_DEVEL=y (defconfig 后 CCACHE 可存活)"
+else
+  bad "common.config 有 CONFIG_CCACHE=y 但缺 CONFIG_DEVEL=y — defconfig 会静默剔除 CCACHE, ccache 空转!"
 fi
 
 scenario "B13 — 每设备 DEVICE 符号必须是上游真实有效符号 (防 r68s 幽灵符号回归)"

--- a/tests/bdd-matrix-build.sh
+++ b/tests/bdd-matrix-build.sh
@@ -62,14 +62,14 @@ assemble() { cat config/common.config "devices/$1/seed.config"; }
 # -----------------------------------------------------------------------------
 # 行为 1: 拼装等价性 (B01/B02/B03)
 # -----------------------------------------------------------------------------
-scenario "B01 — common+seed 逐行还原原始 .config (排除有意新增 CONFIG_CCACHE/CONFIG_DEVEL)"
+scenario "B01 — common+seed 逐行还原原始 .config (排除有意新增项)"
 for dev in $RESTORE_DEVICES; do
   if ! has_ref "$dev:.config"; then
     skip "$dev 基线分支已清理 (ref 不存在), 跳过还原比对"
     continue
   fi
   orig=$(git show "$dev:.config" | effective)
-  asm=$(assemble "$dev" | effective | grep -vE '^CONFIG_(CCACHE|DEVEL)=y$')
+  asm=$(assemble "$dev" | effective | grep -vE '^CONFIG_(CCACHE|DEVEL|KERNEL_SECURITY_LANDLOCK)=y$')
   if diff <(echo "$orig") <(echo "$asm") >/dev/null; then
     ok "$dev 还原一致"
   else
@@ -84,7 +84,7 @@ if ! has_ref "r68s:.config"; then
   skip "r68s 基线分支已清理 (ref 不存在), 跳过非符号行比对"
 else
 orig_r68s=$(git show "r68s:.config" | effective | grep -vE '_DEVICE_.*r68s=y')
-asm_r68s=$(assemble r68s | effective | grep -vE '^CONFIG_(CCACHE|DEVEL)=y$' | grep -vE '_DEVICE_.*r68s=y')
+asm_r68s=$(assemble r68s | effective | grep -vE '^CONFIG_(CCACHE|DEVEL|KERNEL_SECURITY_LANDLOCK)=y$' | grep -vE '_DEVICE_.*r68s=y')
 if diff <(echo "$orig_r68s") <(echo "$asm_r68s") >/dev/null; then
   ok "r68s 除 DEVICE 符号修正外其余完全一致"
 else


### PR DESCRIPTION
## 根因

`config/common.config` 有 `CONFIG_CCACHE=y` 但缺 `CONFIG_DEVEL=y`。

上游 Kconfig 中 CCACHE 的 prompt 定义为：

```
bool "Use ccache" if DEVEL
```

`DEVEL` 关闭时，`make defconfig` 会静默剔除 `CONFIG_CCACHE=y`，编译器全程裸跑，ccache 缓存恒空。CI 的 ccache restore/save 动作虽然执行，但命中率始终为 0——这就是 issue #25 报告的「ccache 全程空转」现象。

## 改动清单

- **config/common.config**：`CONFIG_CCACHE=y` 上方补 `CONFIG_DEVEL=y`
- **tests/bdd-matrix-build.sh**：B01/B01b 还原比对同步剔除对 `DEVEL` 的检查（DEVEL 是 common 应有的内容，不属于设备 delta）；新增 **B03b** 防呆断言，守护 `CONFIG_CCACHE=y` 必伴随 `CONFIG_DEVEL=y`（两者缺一则断言失败）
- **CLAUDE.md**：断言计数 56→57，补 ccache/DEVEL 依赖契约说明

## 本地验证

本地 BDD 57 条断言全绿：

```bash
bash tests/bdd-matrix-build.sh
# PASS: 57 assertions passed, 0 failed
```

## 待 CI 异步验证

触发单设备（r5s）构建后，在 CI log 中确认：

- [ ] 编译期 `ccache` 进程数 > 0（不再裸跑）
- [ ] `staging_dir/host/bin/ccache` 存在
- [ ] 二次构建 `ccache -s` 命中率显著提升（> 0%）

## 关联

fix #25