### PR TITLE
fix: Landlock 改走 config-6.6 直注

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ diy-part1.sh 末尾按 `$DEVICE` 自动 source 对应钩子，无钩子则静默
 - 禁用密码认证，仅允许密钥
 - WAN侧防火墙已开放65422
 - dropbear `Interface 'lan'` 用 `[[:space:]]*` 容差正则解绑（不依赖上游空格数量）
+- Landlock LSM: `CONFIG_KERNEL_SECURITY=y` 走 common.config seed 通道；`SECURITYFS`/`SECURITY_LANDLOCK`/`LSM` 列表因无 OpenWrt Kconfig 入口，由 diy-part2.sh 直注 `target/linux/generic/config-6.6`（社区标准做法）
 
 **系统优化**：
 - 主题: luci-theme-argon（仅 patch 实际编译的 `luci-nginx` collection；`luci`/`luci-ssl-nginx` 两条旧 sed 是死代码已删，后者在 v24.10.6 已并入 luci-nginx）

--- a/config/common.config
+++ b/config/common.config
@@ -16,14 +16,11 @@ CONFIG_TARGET_ROOTFS_SQUASHFS=y
 CONFIG_TARGET_KERNEL_PARTSIZE=32
 CONFIG_TARGET_ROOTFS_PARTSIZE=1024
 
-# Kernel Security — Landlock LSM (全依赖链)
-# CONFIG_SECURITY 是 LSM 基础设施总开关, 缺它 LANDLOCK 被 defconfig 静默丢弃。
-# CONFIG_SECURITYFS 让内核 boot 时自动挂载 /sys/kernel/security (无需 init 脚本)。
-# CONFIG_LSM 列表保留上游 config-6.6 基线并追加 landlock 激活。
+# Kernel Security — Landlock LSM
+# KERNEL_SECURITY 有 OpenWrt Config-kernel.in 入口, 走正常 seed 通道。
+# SECURITYFS / SECURITY_LANDLOCK / LSM 列表无入口 (或入口有 SELinux 前置依赖),
+# 会被 OpenWrt defconfig 静默剥掉; 改由 diy-part2.sh 直注 target/linux/generic/config-6.6。
 CONFIG_KERNEL_SECURITY=y
-CONFIG_KERNEL_SECURITYFS=y
-CONFIG_KERNEL_SECURITY_LANDLOCK=y
-CONFIG_KERNEL_LSM="lockdown,yama,loadpin,safesetid,integrity,landlock"
 
 # Build Acceleration (host-side ccache; arch-neutral, 不影响固件内容)
 # CONFIG_DEVEL 必须置顶: 上游 config/Config-devel.in 把 CCACHE 的 prompt 声明为

--- a/diy-part2.sh
+++ b/diy-part2.sh
@@ -47,6 +47,28 @@ echo "Added UCI Defaults script: package/base-files/files/etc/uci-defaults/99-cu
 
 # --- End: Add UCI Defaults script ---
 
+# --- Kernel Security: Landlock LSM (直注内核配置片段) ---
+# SECURITYFS / SECURITY_LANDLOCK / LSM 在 OpenWrt Config-kernel.in 无有效入口,
+# CONFIG_KERNEL_* 写 seed 会被 OpenWrt defconfig 静默剥掉;
+# 直注 target/linux/generic/config-6.6 是社区标准做法。
+# 注: CONFIG_SECURITY=y 已由 common.config 的 CONFIG_KERNEL_SECURITY=y 通过 OpenWrt
+# Kconfig 正常注入, 此处不重复 sed (冗余注入会在上游启用该选项时触发假阳性 fail-loud)。
+sed_required "kernel: enable CONFIG_SECURITYFS (/sys/kernel/security auto-mount)" \
+  's/^# CONFIG_SECURITYFS is not set$/CONFIG_SECURITYFS=y/' \
+  target/linux/generic/config-6.6
+
+sed_required "kernel: enable CONFIG_SECURITY_LANDLOCK" \
+  's/^# CONFIG_SECURITY_LANDLOCK is not set$/CONFIG_SECURITY_LANDLOCK=y/' \
+  target/linux/generic/config-6.6
+
+# LSM 列表: 反向匹配 + 捕获组动态追加。
+# /landlock/! 确保: 若上游已自带 landlock, 该行含 "landlock" 则 sed 跳过 → 文件未改 →
+# sed_required fail-loud 触发, 逼迫维护者清理废弃 patch。
+# 上游增删其他 LSM (如加 bpf) 不影响 — 捕获组 \(.*\) 抓取任意内容再追加。
+sed_required "kernel: append landlock to CONFIG_LSM activation list" \
+  '/landlock/! s/^CONFIG_LSM="\(.*\)"$/CONFIG_LSM="\1,landlock"/' \
+  target/linux/generic/config-6.6
+
 # Modify default theme (bootstrap -> argon)
 # 仅 patch luci-nginx collection: 这是本项目实际编译的集合 (.config 选 luci-nginx,
 # 不装 luci 元包/不走 uhttpd/不装 luci-ssl-nginx)。v24.10.6 上 luci/Makefile 已无

--- a/tests/bdd-matrix-build.sh
+++ b/tests/bdd-matrix-build.sh
@@ -70,7 +70,7 @@ for dev in $RESTORE_DEVICES; do
     continue
   fi
   orig=$(git show "$dev:.config" | effective)
-  asm=$(assemble "$dev" | effective | grep -vE '^CONFIG_(CCACHE|DEVEL|KERNEL_SECURITY|KERNEL_SECURITYFS|KERNEL_SECURITY_LANDLOCK|KERNEL_LSM|PACKAGE_f2fsck|PACKAGE_sfdisk|PACKAGE_partx-utils)=')
+  asm=$(assemble "$dev" | effective | grep -vE '^CONFIG_(CCACHE|DEVEL|KERNEL_SECURITY|PACKAGE_f2fsck|PACKAGE_sfdisk|PACKAGE_partx-utils)=')
   if diff <(echo "$orig") <(echo "$asm") >/dev/null; then
     ok "$dev 还原一致"
   else
@@ -85,7 +85,7 @@ if ! has_ref "r68s:.config"; then
   skip "r68s 基线分支已清理 (ref 不存在), 跳过非符号行比对"
 else
 orig_r68s=$(git show "r68s:.config" | effective | grep -vE '_DEVICE_.*r68s=y')
-asm_r68s=$(assemble r68s | effective | grep -vE '^CONFIG_(CCACHE|DEVEL|KERNEL_SECURITY|KERNEL_SECURITYFS|KERNEL_SECURITY_LANDLOCK|KERNEL_LSM|PACKAGE_f2fsck|PACKAGE_sfdisk|PACKAGE_partx-utils)=' | grep -vE '_DEVICE_.*r68s=y')
+asm_r68s=$(assemble r68s | effective | grep -vE '^CONFIG_(CCACHE|DEVEL|KERNEL_SECURITY|PACKAGE_f2fsck|PACKAGE_sfdisk|PACKAGE_partx-utils)=' | grep -vE '_DEVICE_.*r68s=y')
 if diff <(echo "$orig_r68s") <(echo "$asm_r68s") >/dev/null; then
   ok "r68s 除 DEVICE 符号修正外其余完全一致"
 else
@@ -131,19 +131,19 @@ else
   bad "common.config 有 CONFIG_CCACHE=y 但缺 CONFIG_DEVEL=y — defconfig 会静默剔除 CCACHE, ccache 空转!"
 fi
 
-scenario "B03c — Landlock 防呆: 四行依赖链必须共存 (SECURITY/SECURITYFS/LANDLOCK/LSM)"
-# 和 B03b (ccache/DEVEL) 同模式: 上游 LANDLOCK 依赖 SECURITY 总开关; 缺了 defconfig
-# 静默丢弃 LANDLOCK 行。SECURITYFS 提供 /sys/kernel/security 验证路径; LSM 列表
-# 含 landlock 才激活模块。任一行缺失 → 功能死代码。
+scenario "B03c — Landlock 防呆: seed 声明 SECURITY + diy 直注 SECURITYFS/LANDLOCK/LSM"
+# common.config 声明 CONFIG_KERNEL_SECURITY=y (有 OpenWrt Kconfig 入口, 走正常通道);
+# 其余三项无入口, 由 diy-part2.sh 直注 target/linux/generic/config-6.6。
+# 此断言跨文件守护: 任一缺失 → Landlock 功能死代码。
 has_security=$(grep -qxF 'CONFIG_KERNEL_SECURITY=y' config/common.config && echo y || echo n)
-has_securityfs=$(grep -qxF 'CONFIG_KERNEL_SECURITYFS=y' config/common.config && echo y || echo n)
-has_landlock=$(grep -qxF 'CONFIG_KERNEL_SECURITY_LANDLOCK=y' config/common.config && echo y || echo n)
-has_lsm_landlock=$(grep -qE '^CONFIG_KERNEL_LSM=.*landlock' config/common.config && echo y || echo n)
-if [ "$has_security" = y ] && [ "$has_securityfs" = y ] \
-   && [ "$has_landlock" = y ] && [ "$has_lsm_landlock" = y ]; then
-  ok "Landlock 四行依赖链齐备 (SECURITY→SECURITYFS→LANDLOCK→LSM 含 landlock)"
+has_diy_securityfs=$(grep -q 'CONFIG_SECURITYFS=y' diy-part2.sh && echo y || echo n)
+has_diy_landlock=$(grep -q 'CONFIG_SECURITY_LANDLOCK=y' diy-part2.sh && echo y || echo n)
+has_diy_lsm=$(grep -qE 'CONFIG_LSM=.*landlock' diy-part2.sh && echo y || echo n)
+if [ "$has_security" = y ] && [ "$has_diy_securityfs" = y ] \
+   && [ "$has_diy_landlock" = y ] && [ "$has_diy_lsm" = y ]; then
+  ok "Landlock: seed KERNEL_SECURITY + diy 直注 SECURITYFS/LANDLOCK/LSM"
 else
-  bad "Landlock 依赖链缺项: SECURITY=$has_security SECURITYFS=$has_securityfs LANDLOCK=$has_landlock LSM含landlock=$has_lsm_landlock"
+  bad "Landlock 不完整: seed_SECURITY=$has_security diy_SECURITYFS=$has_diy_securityfs diy_LANDLOCK=$has_diy_landlock diy_LSM=$has_diy_lsm"
 fi
 
 scenario "B13 — 每设备 DEVICE 符号必须是上游真实有效符号 (防 r68s 幽灵符号回归)"


### PR DESCRIPTION
## Summary

- 上次 PR #29 把 Landlock 四行放 `common.config`，CI 构建通过但实机验证失败：`/sys/kernel/security/landlock/abi_version` 不存在
- 根因：`CONFIG_KERNEL_SECURITYFS` / `CONFIG_KERNEL_SECURITY_LANDLOCK` 在 OpenWrt `Config-kernel.in` 无定义，`CONFIG_KERNEL_LSM` 的入口 `depends on SELinux`——三者均被 OpenWrt `make defconfig` 静默剥掉
- 修复：保留 `CONFIG_KERNEL_SECURITY=y` 走正常 seed 通道（有 Kconfig 入口）；其余三项改由 `diy-part2.sh` 直注 `target/linux/generic/config-6.6`（社区标准做法）
- LSM 列表用 `/landlock/!` 反向匹配 + 捕获组动态追加，不硬编码上游基线

## Test plan

- [x] BDD 70 PASS / 0 FAIL
- [ ] CI 构建通过（sed_required 零匹配 = 构建中断，验证上游行确实存在）
- [ ] 实机 `cat /sys/kernel/security/landlock/abi_version` → 3
- [ ] 实机 `dmesg | grep landlock` 确认 LSM 初始化列表含 landlock